### PR TITLE
Updates for Version 4

### DIFF
--- a/MQ2NetBots.cpp
+++ b/MQ2NetBots.cpp
@@ -25,145 +25,413 @@
 //    - Removed 85/419 from triggering formula. These Procs stack/don't stack based on
 //      the normal base check (for these, it is SpellID). It seems newer spells simply
 //      overwrite older spells.
-
-#define        PLUGIN_NAME "MQ2NetBots"
-#define        PLUGIN_DATE     20190715
-
-#define        GEMS_MAX              NUM_SPELL_GEMS
-#define        BUFF_MAX              NUM_LONG_BUFFS
-#define        SONG_MAX              NUM_SHORT_BUFFS
-#define        PETS_MAX              65
-#define        NOTE_MAX		    500
-#define        DETR_MAX		     30
-
-#define        NETTICK               50
-#define        REFRESH            60000
-#define        UPDATES             6000
-
-#define        DEBUGGING             0
-
-// FIXME:  Why is all this redefined here?  Even without that, get rid of it.
-#define ISINDEX() (Index[0])
-#define ISNUMBER() (IsNumber(Index))
-#define GETNUMBER() (atoi(Index))
-#define GETFIRST() Index
+// v4.0 woobs
+//    - Merged in MMOBUGS data items and in-game window (thank you MMOBUGS).
+//    - Added Detrimental/Beneficial buff type data items.
+//    - Remove internal Stacks/StacksPet. Use new EQ/MQ coding.
+//    - Added WillLand,WillLandPet,TooPowerful,TooPowerfulPet.
+//    - Added Extended data options for Gems and Buff/Song/Pet Durations.
+//    - Added TotalCounters,CountersCurse,CountersDisease,CountersPoison,CountersCorruption
+//      to accurately report current counters on the client (not counters on the spell).
+//    - Added PetAffinity and AAPointsAssigned.
+//    - Added a new version of the in-game window (switchable with old) along with new
+//      ini and command options. LClick,RClick,ConColors,CleanNames. 
+//    - Code clean-up. 
 
 #include <mq/Plugin.h>
-PreSetup(PLUGIN_NAME);
-PLUGIN_VERSION(3.2);
+
+#include <Blech/Blech.h>
+
 #include <string>
-#include "../Blech/Blech.h"
 
-enum {
-	STATE_DEAD = 0x0001, STATE_FEIGN = 0x0002, STATE_DUCK = 0x0004, STATE_BIND = 0x0008,
-	STATE_STAND = 0x0010, STATE_SIT = 0x0020, STATE_MOUNT = 0x0040, STATE_INVIS = 0x0080,
-	STATE_LEV = 0x0100, STATE_ATTACK = 0x0200, STATE_MOVING = 0x0400, STATE_STUN = 0x0800,
-	STATE_RAID = 0x1000, STATE_GROUP = 0x2000, STATE_LFG = 0x4000, STATE_AFK = 0x8000
+PreSetup("MQ2NetBots");
+PLUGIN_VERSION(4.0);
+
+#define PLUGIN_NAME "MQ2NetBots"
+
+bool DEBUGGING = false;
+
+constexpr int PETS_MAX	= MAX_TOTAL_BUFFS_NPC;
+constexpr int NOTE_MAX	= 500;
+constexpr int NETTICK	= 50;
+constexpr int REFRESH	= 60000;
+constexpr int UPDATES	= 6000;
+
+#if defined(ROF2EMU)
+constexpr char PetAAName[] = "Pet Affinity";
+constexpr int  PetAARank   = 1;
+#else
+constexpr char PetAAName[] = "Companion's Suspension";
+constexpr int  PetAARank   = 3;
+#endif
+
+enum eStates : uint32_t {
+	STATE_DEAD 		= 0x00000001,
+	STATE_FEIGN 	= 0x00000002,
+	STATE_DUCK		= 0x00000004,
+	STATE_BIND		= 0x00000008,
+	STATE_STAND		= 0x00000010,
+	STATE_SIT		= 0x00000020,
+	STATE_MOUNT		= 0x00000040,
+	STATE_INVIS		= 0x00000080,
+	STATE_ITU		= 0x00000100,
+	STATE_ATTACK	= 0x00000200,
+	STATE_MOVING	= 0x00000400,
+	STATE_STUN		= 0x00000800,
+	STATE_RAID		= 0x00001000,
+	STATE_GROUP		= 0x00002000,
+	STATE_LFG		= 0x00004000,
+	STATE_AFK		= 0x00008000,
+	STATE_LEV		= 0x00010000,
+	STATE_RANGED	= 0x00020000,
+	STATE_WANTAGGRO	= 0x00040000,
+	STATE_HAVEAGGRO	= 0x00080000,
+	STATE_HOVER		= 0x00100000,
+	STATE_NAVACTIVE	= 0x00200000,
+	STATE_NAVPAUSED	= 0x00400000,
+	STATE_BOTACTIVE	= 0x00800000,
+	STATE_HASPETAA  = 0x01000000
 };
 
-enum {
-	BUFFS, CASTD, ENDUS, EXPER, LEADR, LEVEL, LIFES, MANAS,
-	PBUFF, PETIL, SPGEM, SONGS, STATE, TARGT, ZONES, DURAS,
-	LOCAT, HEADN, AAPTS, OOCST, NOTE, DETR, ESIZE
+enum eElements {
+	E_BUFFS,
+	E_CASTD,
+	E_ENDUS,
+	E_EXPER,
+	E_LEADR,
+	E_LEVEL,
+	E_HPS,
+	E_MANAS,
+	E_PBUFF,
+	E_PETIL,
+	E_SPGEM,
+	E_SONGS,
+	E_STATE,
+	E_TARGT,
+	E_ZONES,
+	E_BUFFD,
+	E_LOCAT,
+	E_HEADN,
+	E_AAPTS,
+	E_OOCST,
+	E_NOTE,
+	E_DETR,
+	E_FREEB,
+	E_EXTEND,
+	E_MACRO,
+	E_FREEI,
+	E_VERSN,
+	E_CAMPS,
+	E_LUAINFO,
+	E_EQBC,
+	E_QUERY,
+	E_BSTAT,
+	E_SONGD,
+	E_PETD,
+	ESIZE
 };
 
-enum {
-	RESERVED, DETRIMENTALS, COUNTERS, BLINDED, CASTINGLEVEL, CHARMED, CURSED, DISEASED, ENDUDRAIN,
-	FEARED, HEALING, INVULNERABLE, LIFEDRAIN, MANADRAIN, MESMERIZED, POISONED, RESISTANCE, ROOTED,
-	SILENCED, SLOWED, SNARED, SPELLCOST, SPELLDAMAGE, SPELLSLOWED, TRIGGR, CORRUPTED, NOCURE, DSIZE
+enum buffTypes {
+	BT_DETRIMENTAL,
+	BT_BENEFICIAL
+};
+
+enum buffDetrimentalStates : uint32_t {
+	BD_SLOWED		= 0x00000001,
+	BD_ROOTED		= 0x00000002,
+	BD_MESMERIZED	= 0x00000004,
+	BD_CRIPPLED		= 0x00000008,
+	BD_MALOED		= 0x00000010,
+	BD_TASHED		= 0x00000020,
+	BD_SNARED		= 0x00000040,
+	BD_REVDSED		= 0x00000080,
+	BD_CHARMED		= 0x00000100,
+	BD_DISEASED		= 0x00000200,
+	BD_POISONED		= 0x00000400,
+	BD_CURSED		= 0x00000800,
+	BD_CORRUPTED	= 0x00001000,
+	BD_BLINDED		= 0x00002000,
+	BD_CASTINGLEVEL	= 0x00004000,
+	BD_ENDUDRAIN	= 0x00008000,
+	BD_FEARED		= 0x00010000,
+	BD_HEALING		= 0x00020000,
+	BD_INVULNERABLE	= 0x00040000,
+	BD_LIFEDRAIN	= 0x00080000,
+	BD_MANADRAIN	= 0x00100000,
+	BD_RESISTANCE	= 0x00200000,
+	BD_SILENCED		= 0x00400000,
+	BD_SPELLCOST	= 0x00800000,
+	BD_SPELLDAMAGE	= 0x01000000,
+	BD_SPELLSLOWED	= 0x02000000,
+	BD_TRIGGER		= 0x04000000 
+};
+
+enum buffBeneficialStates : uint32_t {
+	BB_DSED			= 0x00000001,
+	BB_AEGO			= 0x00000002,
+	BB_SKIN			= 0x00000004,
+	BB_FOCUS		= 0x00000008,
+	BB_REGEN		= 0x00000010,
+	BB_SYMBOL		= 0x00000020,
+	BB_CLARITY		= 0x00000040,
+	BB_PRED			= 0x00000080,
+	BB_STRENGTH		= 0x00000100,
+	BB_BRELLS		= 0x00000200,
+	BB_SV			= 0x00000400,
+	BB_SE			= 0x00000800,
+	BB_HYBRIDHP		= 0x00001000,
+	BB_GROWTH		= 0x00002000,
+	BB_SHINING		= 0x00004000,
+	BB_HASTED		= 0x00008000
+};
+
+enum eSpellTypes {
+	ST_SLOWED = 1,
+	ST_ROOTED,
+	ST_MESMERIZED,
+	ST_CRIPPLED,
+	ST_MALOED,
+	ST_TASHED,
+	ST_SNARED,
+	ST_REVDSED,
+	ST_CHARMED,
+	ST_DISEASED,
+	ST_POISONED,
+	ST_CURSED,
+	ST_CORRUPTED,
+	ST_BLINDED,
+	ST_CASTINGLEVEL,
+	ST_ENDUDRAIN,
+	ST_FEARED,
+	ST_HEALING,
+	ST_INVULNERABLE,
+	ST_LIFEDRAIN,
+	ST_MANADRAIN,
+	ST_RESISTANCE,
+	ST_SILENCED,
+	ST_SPELLCOST,
+	ST_SPELLDAMAGE,
+	ST_SPELLSLOWED,
+	ST_TRIGGER,
+	ST_DSED,
+	ST_AEGO,
+	ST_SKIN,
+	ST_FOCUS,
+	ST_REGEN,
+	ST_SYMBOL,
+	ST_CLARITY,
+	ST_PRED,
+	ST_STRENGTH,
+	ST_BRELLS,
+	ST_SV,
+	ST_SE,
+	ST_HYBRIDHP,
+	ST_GROWTH,
+	ST_SHINING,
+	ST_HASTED
+};
+
+enum eDetrimentals {
+	D_DETRIMENTALS,
+	D_COUNTERS,
+	D_CURSED,
+	D_DISEASED,
+	D_POISONED,
+	D_CORRUPTED,
+	D_NOCURE,
+	D_LIFEDRAIN,
+	D_MANADRAIN,
+	D_ENDUDRAIN,
+	DSIZE
+};
+
+enum eItemSize {
+	I_TINY = 0,
+	I_SMALL = 1,
+	I_MEDIUM = 2,
+	I_LARGE = 3,
+	I_GIANT = 4,
+	ISIZE
+};
+
+enum eMacroStatus {
+	MACRO_NONE,
+	MACRO_RUNNING,
+	MACRO_PAUSED
+};
+
+enum eClickActions {
+	CA_NO_ACTION = 0,
+	CA_BRING_TO_FOREGROUND = 1,
+	CA_TARGET_PLAYER = 2,
+	CA_TARGET_PLAYER_TARGET = 3,
+	CASIZE
+};
+
+enum eInvisStates : uint32_t {
+	INVIS_NORMAL = 0x00000001,
+	INVIS_UNDEAD = 0x00000002
+};
+
+enum eExtended {
+	EX_NONE = 0,
+	EX_GEMS_AND_BUFF_DURATIONS = 1,
+	EX_SONG_DURATIONS = 2,
+	EX_PET_DURATIONS = 3,
+	EXSIZE
+};
+
+struct CaseInsensitiveComparator
+{
+    bool operator() (const std::string& a, const std::string& b) const noexcept
+    {
+        return _stricmp(a.c_str(), b.c_str()) < 0;
+    }
 };
 
 class BotInfo {
 public:
-	CHAR              Name[0x40];          // Client NAME
-	CHAR              Leader[0x40];        // Leader Name
-	WORD              State;               // State
-	long              ZoneID;              // Zone ID
-	long              InstID;              // Instance ID
-	long              SpawnID;             // Spawn ID
-	long              ClassID;             // Class ID
-	long              Level;               // Level
-	long              CastID;              // Casting Spell ID
-	long              LifeCur;             // HP Current
-	long              LifeMax;             // HP Maximum
-	long              EnduCur;             // ENDU Current
-	long              EnduMax;             // ENDU Maximum
-	long              ManaCur;             // MANA Current
-	long              ManaMax;             // MANA Maximum
-	long              PetID;               // PET ID
-	long              PetHP;               // PET HP Percentage
-	long              TargetID;            // Target ID
-	long              TargetHP;            // Target HP Percentage
-  //  long              Gem[GEMS_MAX];       // Spell Memorized
-	long              Pets[PETS_MAX];      // Spell Pets
-	long              Song[SONG_MAX];      // Spell Song
-	long              Buff[BUFF_MAX];      // Spell Buff
-  //  long              Duration[BUFF_MAX];  // Buff duration
-	long              FreeBuff;            // FreeBuffSlot;
+	char        Name[EQ_MAX_NAME];          // Client Name
+	int         ClassID;                    // Class ID
+	int         Level;                      // Level
+	int         SpawnID;                    // Spawn ID
+	int         ZoneID;                     // Zone ID
+	int         InstanceID;                 // Instance ID
+	int         HPCurrent;                  // HP Current
+	int         HPMax;                      // HP Maximum
+	int         ManaCurrent;                // Mana Current
+	int         ManaMax;                    // Mana Maximum
+	int         EnduranceCurrent;           // Endurance Current
+	int         EnduranceMax;               // Endurance Maximum
+	int         PetID;                      // Pet ID
+	int         PetHPPct;                   // Pet HP Percentage
+	int         TargetID;                   // Target ID
+	int         TargetHPPct;                // Target HP Percentage
+    int         Gem[NUM_SPELL_GEMS];        // Spells Memorized
+	int         Buff[NUM_LONG_BUFFS];       // Buffs
+	int         Song[NUM_SHORT_BUFFS];      // Songs
+	int         Pets[PETS_MAX];             // Pet Buffs
+    int         BDuration[NUM_LONG_BUFFS];  // Buff durations
+    int         SDuration[NUM_SHORT_BUFFS]; // Song durations
+    int         PDuration[PETS_MAX];        // Pet Buff durations
+	int         FreeBuff;                   // Free Buff Slots
+	int         CastID;                     // Casting Spell ID
+	int         CombatState;                // Combat State
+	int64_t     Exp;                        // Experience
+	uint32_t    AAExp;                      // AA Experience
 #if HAS_LEADERSHIP_EXPERIENCE
-	double            glXP;                // glXP
+	double      GroupLeaderExp;             // Group Leadership Experience
 #endif
-	DWORD             aaXP;                // aaXP
-	DWORD             XP;                  // XP
-	DWORD             Updated;             // Update
-	CHAR              Location[0x40];      // Y,X,Z
-	CHAR		    Heading[0x40];       // Heading
-	long              TotalAA;             // totalAA
-	long              UsedAA;              // usedAA
-	long              UnusedAA;            // unusedAA
-	DWORD             CombatState;         // CombatState
-	CHAR              Note[NOTE_MAX];      // User Mesg
-	int               Detrimental[DSIZE];
+	char        Leader[EQ_MAX_NAME];        // Group Leader Name
+	char        Location[64];               // Y,X,Z
+    float       X;                          // Location X-value
+    float       Y;                          // Location Y-value
+    float       Z;                          // Location Z-value
+	char		Heading[64];                // Heading
+	int         AAPoints;                   // Unused AA Points
+	int         AAPointsSpent;              // Spent AA Points
+	int         AAPointsAssigned;           // Assigned AA Points
+	uint32_t    State;                      // State
+	uint32_t    DetrState;                  // Detrimental Buff States
+	uint32_t    BeneState;                  // Beneficial Buff States
+	int64_t     Detrimental[DSIZE];         // Detrimentals
+	int         FreeInventory[ISIZE];       // Free Inventory Slots of, at least, size 0-4
+	float       Version;                    // Plugin Version
+	int         Extended;                   // Extended Setting
+	int         MacroState;                 // Current Macro State (0=No Macro Running,1=Running,2=Paused)
+	char        MacroName[MAX_PATH];        // Current Macro Name
+	int         MakeCampStatus;             // MakeCamp Status (0=None/OFF,1=ON,2=PAUSED)
+	float       MakeCampX;                  // MakeCamp AnchorX
+	float       MakeCampY;                  // MakeCamp AnchorY
+	float       MakeCampRadius;             // MakeCamp CampRadius
+	float       MakeCampDistance;           // MakeCamp CampDistance
+	char        LuaInfo[MAX_STRING];        // LUA Process Info
+	uint64_t    EQBC_Packets;               // EQBC Packets
+	uint64_t    EQBC_HeartBeat;             // EQBC HeartBeat
+	char        Note[NOTE_MAX];             // User Message
+	char        Query[MAX_STRING];          // Result of NetQuery
+	uint32_t    Updated;                    // Update Time
 };
 
-long                NetInit = 0;           // Plugin Initialized?
-long                NetStat = 0;           // Plugin is On?
-long                NetGrab = 0;           // Grab Information?
-long                NetSend = 0;           // Send Information?
-long                NetLast = 0;           // Last Send Time Mark
-char                NetNote[NOTE_MAX];   // Network Note
+int             NetInit = 0;                // Plugin Initialized?
+int             NetStat = 0;                // Plugin is On?
+int             NetGrab = 0;                // Grab Information?
+int             NetSend = 0;                // Send Information?
+int             NetExtended = 0;            // Send Extended Information (0=None, 1=Gems+Buff Durations, 2=Add Short Durations, 3= Add Pet Buff Durations)
+int             NetSimple = 0;              // Allow any substring of Buff/ShortBuff/PetBuff to return result
+int             NetShow = 0;                // Show UI window?
+int             NetLClick = 0;              // UI Window Left Click Action
+int             NetRClick = 0;              // UI Window Right Click Action
+int             NetConColors = 0;           // Use NPC Con Colors in UI Window
+int             NetCleanNames = 0;          // Use NPC Clean Names in UI Window
+int             NetRightMost = 0;           // If > 0, only send this number right-most characters of target name in UI Window
+int             NetUseNewWindow = -1;       // 0/1 Use Old/New NetBots Window layout (requires the associated MQUI_NetBotsWnd.xml file)
+int             NetEQBCData = 0;            // Send EQBC Packets/Heartbeat data
+int             NetLast = 0;                // Last Send Time Mark
+uint64_t        ShowTime = 0;               // Window Show Time Mark
+char            NetNote[NOTE_MAX];          // Network Note
+char            NetQuery[MAX_STRING];       // Network Query
+char            NetWindowTitle[MAX_STRING]; // UI Window Title (Can be Macro-Parsed)
 
-std::map<std::string, std::shared_ptr<BotInfo>> NetMap;              // BotInfo Mapped List
-Blech               Packet('#');         // BotInfo Event Triggers
-BotInfo            *CurBot = 0;            // BotInfo Current
+std::map<std::string, std::shared_ptr<BotInfo>, CaseInsensitiveComparator> NetMap;  // BotInfo Mapped List
+Blech           Packet('#');                                                        // BotInfo Event Triggers
+BotInfo         *CurBot = 0;                                                        // BotInfo Current Bot
 
-long                sTimers[ESIZE];      // Save Timers
-char                sBuffer[ESIZE][2048]; // Save Buffer
-char                wBuffer[ESIZE][2048]; // Work Buffer
-bool                wChange[ESIZE];      // Work Change
-bool                wUpdate[ESIZE];      // Work Update
+int             sTimers[ESIZE];      		// Save Timers
+char            sBuffer[ESIZE][MAX_STRING]; // Save Buffer
+char            wBuffer[ESIZE][MAX_STRING]; // Work Buffer
+bool            wChange[ESIZE];     		// Work Change
+bool            wUpdate[ESIZE];    			// Work Update
 
-int                 dValues[DSIZE];
+char            bBuffs[MAX_STRING];         // Buff List
+char            bSongs[MAX_STRING];         // Song List
+char            bPBuffs[MAX_STRING];        // Pet Buff List
+char            bBuffd[MAX_STRING];         // Buff Duration List
+char            bSongd[MAX_STRING];         // Song Duration List
+char            bPBuffd[MAX_STRING];        // Pet Buff Duration List
+uint32_t        detrStatus;                 // Detrimental Buff Status (States)
+uint32_t        beneStatus;                 // Beneficial Buff Status (States)
+uint32_t        invisStatus;                // Invisible Buff Status (States)
+int64_t         dValues[DSIZE];             // Detrimental Counters and Drain Values
+int             AvailBuffSlots;             // Available Buff Slots
+
+char            GlobalINIFileName[MAX_STRING] = { 0 };
+char            PlayerSectionName[MAX_STRING] = { 0 };
+char            WindowID[MAX_STRING]          = { 0 };
+char            ScreenID[MAX_STRING]          = { 0 };
+
+struct BuffData {							// Buff Data (for mapped list)
+	int 		Type;						// Buff Type (BT_) Enum
+	uint32_t	State;						// Buff Detrimental/Benefical State (BD_/BB_) Enum
+	int			SpellType;					// Buff Spell Type (ST_) Enum
+	
+	BuffData(int i, uint32_t j, int k) : Type(i), State(j), SpellType(k) {}
+};
+std::map<std::string, BuffData> BuffMap;	// Buff Data Mapped List
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
 
 bool EQBCConnected() {
 	using fEqbcIsConnected = uint16_t(*)();
-	auto pLook = pPlugins;
-	while (pLook && _strnicmp(pLook->szFilename, "mq2eqbc", 8)) pLook = pLook->pNext;
-	if (pLook)
-		if (fEqbcIsConnected checkf = (fEqbcIsConnected)GetProcAddress(pLook->hModule, "isConnected"))
-			if (checkf()) return true;
+	if (fEqbcIsConnected checkf = (fEqbcIsConnected)GetPluginProc("MQ2EQBC", "isConnected")) {
+		return checkf();
+	}
 	return false;
 }
 
 void EQBCBroadCast(const char* Buffer) {
 	using fEqbcNetBotSendMsg = void(*)(const char*);
 	if (strlen(Buffer) > 9) {
-		auto pLook = pPlugins;
-		while (pLook && _strnicmp(pLook->szFilename, "mq2eqbc", 8)) pLook = pLook->pNext;
-		if (pLook)
-			if (fEqbcNetBotSendMsg requestf = (fEqbcNetBotSendMsg)GetProcAddress(pLook->hModule, "NetBotSendMsg")) {
-#if    DEBUGGING>1
+		if (fEqbcNetBotSendMsg requestf = (fEqbcNetBotSendMsg)GetPluginProc("MQ2EQBC", "NetBotSendMsg")) {
+			if (DEBUGGING) {
 				DebugSpewAlways("%s->BroadCasting(%s)", PLUGIN_NAME, Buffer);
-#endif DEBUGGING
-				requestf(Buffer);
 			}
+			requestf(Buffer);
+		}
 	}
 }
 
-std::shared_ptr<BotInfo> BotLoad(const char* Name)
-{
+std::shared_ptr<BotInfo> BotLoad(const char* Name) {
 	BotInfo RecInfo;
 	ZeroMemory(&RecInfo.Name, sizeof(BotInfo));
 	strcpy_s(RecInfo.Name, Name);
@@ -171,757 +439,1195 @@ std::shared_ptr<BotInfo> BotLoad(const char* Name)
 	return f->second;
 }
 
-void BotQuit(PCHAR Name) {
+void BotQuit(const char* Name) {
 	auto f = NetMap.find(Name);
-	if (NetMap.end() != f) NetMap.erase(f);
-}
-
-//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
-
-bool inGroup(unsigned long ID) {
-	auto pID = (PSPAWNINFO)GetSpawnByID(ID);
-	if (pID && pID->MasterID) pID = (PSPAWNINFO)GetSpawnByID(pID->MasterID);
-	if (pID && GetCharInfo() && GetCharInfo()->pSpawn) {
-		if (GetCharInfo()->pSpawn->SpawnID == pID->SpawnID)   return true;
-		if (GetCharInfo()->pGroupInfo) for (int G = 1; G < 6; G++)
-			if (auto pSpawn = GetGroupMember(G))
-				if (pID->SpawnID == pSpawn->SpawnID)  return true;
-	}
-	return false;
-}
-
-bool inZoned(unsigned long zID, unsigned long iID) {
-	return (GetCharInfo() && GetCharInfo()->zoneId == zID && GetCharInfo()->instance == iID);
-}
-
-int64_t NBGetEffectAmt(PSPELL pSpell, int i)
-{
-	int spa = GetSpellAttrib(pSpell, i);
-	int64_t base = GetSpellBase(pSpell, i);
-	int64_t max = GetSpellMax(pSpell, i);
-	int calc = GetSpellCalc(pSpell, i);
-
-	if (spa == SPA_NOSPELL)
-		return 0;
-
-	if (spa == SPA_CHA && (base <= 1 || base > 255))
-		return 0;
-
-	switch (spa)
-	{
-	case SPA_HASTE:
-	case SPA_HEIGHT:
-	case SPA_BARD_HASTE: // Adjust for Base=100
-		base -= 100;
-		max -= 100;
-		break;
-	case SPA_SUMMON_CORPSE: // Adjust for base/max swapped
-		max = base;
-		base = 0;
-		break;
-	case SPA_FOCUS_DAMAGE_MOD:
-	case SPA_FOCUS_HEAL_MOD:
-	case SPA_FOCUS_MANACOST_MOD: // Adjust for base2 used as max
-		max = GetSpellBase2(pSpell, i);
-		break;
-	case SPA_FOCUS_REAGENT_MOD:
-	case SPA_FOCUS_DAMAGE_AMT_DETRIMENTAL: // Adjust for base2 used as base
-		base = GetSpellBase2(pSpell, i);
-		break;
-	}
-
-	int64_t value = CalcValue(calc, (spa == SPA_STACKING_BLOCK) ? max : base, max, 1);
-	return value;
-}
-
-// ***************************************************************************
-// Function:    LargerEffectTest
-// Description: Return boolean true if the spell effect is to be ignored
-//              for stacking purposes
-// ***************************************************************************
-BOOL NBLargerEffectTest(PSPELL aSpell, PSPELL bSpell, int i)
-{
-	LONG aAttrib = GetSpellNumEffects(aSpell) > i ? GetSpellAttrib(aSpell, i) : 254;
-	LONG bAttrib = GetSpellNumEffects(bSpell) > i ? GetSpellAttrib(bSpell, i) : 254;
-	if (aAttrib == bAttrib)
-		return abs(NBGetEffectAmt(aSpell, i)) >= abs(NBGetEffectAmt(bSpell, i));
-	return false;
-}
-
-// ***************************************************************************
-// Function:    TriggeringEffectSpell
-// Description: Return boolean true if the spell effect is to be ignored
-//              for stacking purposes
-// ***************************************************************************
-BOOL NBTriggeringEffectSpell(PSPELL aSpell, int i)
-{
-	LONG aAttrib = GetSpellNumEffects(aSpell) > i ? GetSpellAttrib(aSpell, i) : 254;
-	return (aAttrib == 374		// Trigger Spell
-		|| aAttrib == 442 	// Trigger Effect
-		|| aAttrib == 443 	// Trigger Effect
-		|| aAttrib == 453 	// Trigger Effect
-		|| aAttrib == 454 	// Trigger Effect
-		|| aAttrib == 470 	// Trigger Effect
-		|| aAttrib == 475 	// Trigger Spell Non-Item
-		|| aAttrib == 481); 	// Trigger Spell
-}
-
-// ***************************************************************************
-// Function:    DurationWindowTest
-// Description: Return boolean true if the spell effect is to be ignored
-//              for stacking purposes
-// ***************************************************************************
-BOOL NBDurationWindowTest(PSPELL aSpell, PSPELL bSpell, int i)
-{
-	LONG aAttrib = GetSpellNumEffects(aSpell) > i ? GetSpellAttrib(aSpell, i) : 254;
-	LONG bAttrib = GetSpellNumEffects(bSpell) > i ? GetSpellAttrib(bSpell, i) : 254;
-	if ((aSpell->SpellType != 1 && aSpell->SpellType != 2) || (bSpell->SpellType != 1 && bSpell->SpellType != 2) || (aSpell->DurationWindow == bSpell->DurationWindow))
-		return false;
-	return (!(aAttrib == bAttrib &&
-		(aAttrib == 2		// Attack Mod
-			|| aAttrib == 162))); 	// Mitigate Melee Damage
-}
-
-// ***************************************************************************
-// Function:    SpellEffectTest
-// Description: Return boolean true if the spell effect is to be ignored
-//              for stacking purposes
-// ***************************************************************************
-BOOL NBSpellEffectTest(PSPELL aSpell, PSPELL bSpell, int i, BOOL bIgnoreTriggeringEffects, BOOL bIgnoreCrossDuration)
-{
-	LONG aAttrib = GetSpellNumEffects(aSpell) > i ? GetSpellAttrib(aSpell, i) : 254;
-	LONG bAttrib = GetSpellNumEffects(bSpell) > i ? GetSpellAttrib(bSpell, i) : 254;
-	return ((aAttrib == 57 || bAttrib == 57)		// Levitate
-		|| (aAttrib == 79 || bAttrib == 79)		// +HP when cast (priest buffs that have heal component, DoTs with DDs)
-		|| (aAttrib == 134 || bAttrib == 134)		// Limit: Max Level
-		|| (aAttrib == 135 || bAttrib == 135)		// Limit: Resist
-		|| (aAttrib == 136 || bAttrib == 136)		// Limit: Target
-		|| (aAttrib == 137 || bAttrib == 137)		// Limit: Effect
-		|| (aAttrib == 138 || bAttrib == 138)		// Limit: SpellType
-		|| (aAttrib == 139 || bAttrib == 139)		// Limit: Spell
-		|| (aAttrib == 140 || bAttrib == 140)		// Limit: Min Duraction
-		|| (aAttrib == 141 || bAttrib == 141)		// Limit: Instant
-		|| (aAttrib == 142 || bAttrib == 142)		// Limit: Min Level
-		|| (aAttrib == 143 || bAttrib == 143)		// Limit: Min Cast Time
-		|| (aAttrib == 144 || bAttrib == 144)		// Limit: Max Cast Time
-		|| (aAttrib == 254 || bAttrib == 254)		// Placeholder
-		|| (aAttrib == 311 || bAttrib == 311)		// Limit: Combat Skills not Allowed
-		|| (aAttrib == 339 || bAttrib == 339)		// Trigger DoT on cast
-		|| (aAttrib == 340 || bAttrib == 340)		// Trigger DD on cast
-		|| (aAttrib == 348 || bAttrib == 348)		// Limit: Min Mana
-		|| (aAttrib == 385 || bAttrib == 385)		// Limit: Spell Group
-		|| (aAttrib == 391 || bAttrib == 391)		// Limit: Max Mana
-		|| (aAttrib == 403 || bAttrib == 403)		// Limit: Spell Class
-		|| (aAttrib == 404 || bAttrib == 404)		// Limit: Spell Subclass
-		|| (aAttrib == 411 || bAttrib == 411)		// Limit: Player Class
-		|| (aAttrib == 412 || bAttrib == 412)		// Limit: Race
-		|| (aAttrib == 414 || bAttrib == 414)		// Limit: Casting Skill
-		|| (aAttrib == 415 || bAttrib == 415)		// Limit: Item Class
-		|| (aAttrib == 420 || bAttrib == 420)		// Limit: Use
-		|| (aAttrib == 421 || bAttrib == 421)		// Limit: Use Amt
-		|| (aAttrib == 422 || bAttrib == 422)		// Limit: Use Min
-		|| (aAttrib == 423 || bAttrib == 423)		// Limit: Use Type
-		|| (aAttrib == 428 || bAttrib == 428)		// Limit: Skill
-		|| (aAttrib == 460 || bAttrib == 460)		// Limit: Include Non-Focusable
-		|| (aAttrib == 479 || bAttrib == 479)		// Limit: Value
-		|| (aAttrib == 480 || bAttrib == 480)		// Limit: Value
-		|| (aAttrib == 485 || bAttrib == 485)		// Limit: Caster Class
-		|| (aAttrib == 486 || bAttrib == 486)		// Limit: Caster
-		|| (NBLargerEffectTest(aSpell, bSpell, i))	// Ignore if the new effect is greater than the old effect
-		|| (bIgnoreTriggeringEffects && (NBTriggeringEffectSpell(aSpell, i) || NBTriggeringEffectSpell(bSpell, i)))  // Ignore triggering effects validation
-		|| (bIgnoreCrossDuration && NBDurationWindowTest(aSpell, bSpell, i)));	// Ignore if the effects cross Long/Short Buff windows (with exceptions)
-}
-
-// ***************************************************************************
-// Function:    BuffStackTest
-// Description: Return boolean true if the two spells will stack
-// ***************************************************************************
-BOOL NBBuffStackTest(PSPELL aSpell, PSPELL bSpell, BOOL bIgnoreTriggeringEffects, BOOL bIgnoreCrossDuration)
-{
-	if (aSpell->ID == bSpell->ID)
-		return true;
-
-	// We need to loop over the largest of the two, this may seem silly but one could have stacking command blocks
-	// which we will always need to check.
-	int effects = std::max(GetSpellNumEffects(aSpell), GetSpellNumEffects(bSpell));
-	for (int i = 0; i < effects; i++) {
-		// Compare 1st Buff to 2nd. If Attrib[i]==254 its a place holder. If it is 10 it
-		// can be 1 of 3 things: PH(Base=0), CHA(Base>0), Lure(Base=-6). If it is Lure or
-		// Placeholder, exclude it so slots don't match up. Now Check to see if the slots
-		// have equal attribute values to check for stacking.
-		int aAttrib = 254, bAttrib = 254; // Default to placeholder ...
-		int64_t aBase = 0, bBase = 0, aBase2 = 0, bBase2 = 0;
-		if (GetSpellNumEffects(aSpell) > i) {
-			aAttrib = GetSpellAttrib(aSpell, i);
-			aBase = GetSpellBase(aSpell, i);
-			aBase2 = GetSpellBase2(aSpell, i);
-		}
-		if (GetSpellNumEffects(bSpell) > i) {
-			bAttrib = GetSpellAttrib(bSpell, i);
-			bBase = GetSpellBase(bSpell, i);
-			bBase2 = GetSpellBase2(bSpell, i);
-		}
-		//		if (TriggeringEffectSpell(aSpell, i) || TriggeringEffectSpell(bSpell, i)) {
-		//			if (!BuffStackTest(GetSpellByID(TriggeringEffectSpell(aSpell, i) ? aBase2 : aSpell->ID), GetSpellByID(TriggeringEffectSpell(bSpell, i) ? bBase2 : bSpell->ID), bIgnoreTriggeringEffects))
-		//				return false;
-		//		}
-		if (bAttrib == aAttrib && !NBSpellEffectTest(aSpell, bSpell, i, bIgnoreTriggeringEffects, bIgnoreCrossDuration)) {
-			if (!((bAttrib == 10 && (bBase == -6 || bBase == 0)) ||
-				(aAttrib == 10 && (aBase == -6 || aBase == 0)) ||
-				(bAttrib == 79 && bBase > 0 && bSpell->TargetType == 6) ||
-				(aAttrib == 79 && aBase > 0 && aSpell->TargetType == 6) ||
-				(bAttrib == 0 && bBase < 0) ||
-				(aAttrib == 0 && aBase < 0) ||
-				(bAttrib == 148 || bAttrib == 149) ||
-				(aAttrib == 148 || aAttrib == 149))) {
-				return false;
-			}
-		}
-		// Check to see if second buff blocks first buff:
-		// 148: Stacking: Block new spell if slot %d is effect
-		// 149: Stacking: Overwrite existing spell if slot %d is effect
-		if (bAttrib == 148 || bAttrib == 149) {
-			// in this branch we know bSpell has enough slots
-			int tmpSlot = (int)(bAttrib == 148 ? bBase2 - 1 : GetSpellCalc(bSpell, i) - 200 - 1);
-			int64_t tmpAttrib = bBase;
-			if (GetSpellNumEffects(aSpell) > tmpSlot) { // verify aSpell has that slot
-				if (GetSpellMax(bSpell, i) > 0) {
-					int64_t tmpVal = abs(GetSpellMax(bSpell, i));
-					if (GetSpellAttrib(aSpell, tmpSlot) == tmpAttrib && GetSpellBase(aSpell, tmpSlot) < tmpVal) {
-						return false;
-					}
-				}
-				else if (GetSpellAttrib(aSpell, tmpSlot) == tmpAttrib) {
-					return false;
-				}
-			}
-		}
-		/*
-		// Now Check to see if the first buff blocks second buff. This is necessary
-		// because only some spells carry the Block Slot. Ex. Brells and Spiritual
-		// Vigor don't stack Brells has 1 slot total, for HP. Vigor has 4 slots, 2
-		// of which block Brells.
-		if (aAttrib == 148 || aAttrib == 149) {
-			// in this branch we know aSpell has enough slots
-			int tmpSlot = (aAttrib == 148 ? aBase2 - 1 : GetSpellCalc(aSpell, i) - 200 - 1);
-			int tmpAttrib = aBase;
-			if (GetSpellNumEffects(bSpell) > tmpSlot) { // verify bSpell has that slot
-				if (GetSpellMax(aSpell, i) > 0) {
-					int tmpVal = abs(GetSpellMax(aSpell, i));
-					if (GetSpellAttrib(bSpell, tmpSlot) == tmpAttrib && GetSpellBase(bSpell, tmpSlot) < tmpVal) {
-						return false;
-					}
-				}
-				else if (GetSpellAttrib(bSpell, tmpSlot) == tmpAttrib) {
-					return false;
-				}
-			}
-		}
-		*/
-	}
-	return true;
+	if (NetMap.end() != f)
+		NetMap.erase(f);
 }
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
 
 void InfoSong(BotInfo* botInfo, const char* Line) {
-	char Buf[MAX_STRING];
-	for (long Idx = 0; Idx < SONG_MAX; Idx++) {
-		GetArg(Buf, Line, Idx + 1, FALSE, FALSE, FALSE, ':');
-		botInfo->Song[Idx] = atol(Buf);
+	char szTemp[MAX_STRING];
+	for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->Song[i] = GetIntFromString(szTemp, 0);
 	}
 }
 
 void InfoPets(BotInfo* botInfo, const char* Line) {
-	char Buf[MAX_STRING];
-	for (long Idx = 0; Idx < PETS_MAX; Idx++) {
-		GetArg(Buf, Line, Idx + 1, FALSE, FALSE, FALSE, ':');
-		botInfo->Pets[Idx] = atol(Buf);
+	char szTemp[MAX_STRING];
+	for (int i = 0; i < PETS_MAX; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->Pets[i] = GetIntFromString(szTemp, 0);
 	}
 }
 
-/*
-void InfoGems(PCHAR Line) {
-  char Buf[MAX_STRING];
-  for(long Idx=0; Idx<GEMS_MAX; Idx++) {
-	GetArg(Buf,Line,Idx+1,FALSE,FALSE,FALSE,':');
-	CurBot->Gem[Idx]=atol(Buf);
-  }
+void InfoGems(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	for(int i = 0; i < NUM_SPELL_GEMS; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->Gem[i] = GetIntFromString(szTemp, 0);
+	}
 }
-*/
 
 void InfoBuff(BotInfo* botInfo, const char* Line) {
-	char Buf[MAX_STRING];
-	for (long Idx = 0; Idx < BUFF_MAX; Idx++) {
-		GetArg(Buf, Line, Idx + 1, FALSE, FALSE, FALSE, ':');
-		botInfo->Buff[Idx] = atol(Buf);
+	char szTemp[MAX_STRING];
+	for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->Buff[i] = GetIntFromString(szTemp, 0);
 	}
 }
 
-/*
-void InfoDura(PCHAR Line) {
-  char Buf[MAX_STRING];
-  for(long Idx=0; Idx<BUFF_MAX; Idx++) {
-//  WriteChatf("We got=%s", Line);
-	GetArg(Buf,Line,Idx+1,FALSE,FALSE,FALSE,':');
-	CurBot->Duration[Idx]=atol(Buf);
-//   WriteChatf("Set Duration to %s", Buf);
-//   WriteChatf("CurBot->Duration is %d", CurBot->Duration[Idx]);
-  }
+void InfoBDura(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	for(int i = 0; i < NUM_LONG_BUFFS; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->BDuration[i] = GetIntFromString(szTemp, 0);
+	}
 }
-*/
+
+void InfoSDura(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	for(int i = 0; i < NUM_SHORT_BUFFS; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->SDuration[i] = GetIntFromString(szTemp, 0);
+	}
+}
+
+void InfoPDura(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	for(int i = 0; i < PETS_MAX; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->PDuration[i] = GetIntFromString(szTemp, 0);
+	}
+}
 
 void InfoDetr(BotInfo* botInfo, const char* Line) {
-	char Buf[MAX_STRING];
-	for (long Idx = 0; Idx < DSIZE; Idx++) {
-		GetArg(Buf, Line, Idx + 1, FALSE, FALSE, FALSE, ':');
-		botInfo->Detrimental[Idx] = atoi(Buf);
+	char szTemp[MAX_STRING];
+	for (int i = 0; i < DSIZE; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->Detrimental[i] = GetInt64FromString(szTemp, 0);
 	}
 }
 
-int SlotCalculate(PSPELL spell, int slot) {
-	char Buf[MAX_STRING] = { 0 };
-	SlotValueCalculate(Buf, spell, slot, 1);
-	return atoi(Buf);
+void InfoLoc(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	strcpy_s(botInfo->Location, Line);
+	GetArg(szTemp, Line, 1, FALSE, FALSE, FALSE, ':');
+	botInfo->Y = GetFloatFromString(szTemp, 0);
+	GetArg(szTemp, Line, 2, FALSE, FALSE, FALSE, ':');
+	botInfo->X = GetFloatFromString(szTemp, 0);
+	GetArg(szTemp, Line, 3, FALSE, FALSE, FALSE, ':');
+	botInfo->Z = GetFloatFromString(szTemp, 0);
 }
 
-void __stdcall ParseInfo(unsigned int ID, void *pData, PBLECHVALUE pValues) {
-	if (CurBot) while (pValues) {
-		//WriteChatf("Parsing=%s", pValues->Name);
-		int tmpInt = GetIntFromString(pValues->Value, 0);
-		switch (GetIntFromString(pValues->Name, 0)) {
-			case  1:
-				CurBot->ZoneID = tmpInt;
-				break;
-			case  2:
-				CurBot->InstID = tmpInt;
-				break;
-			case  3:
-				CurBot->SpawnID = tmpInt;
-				break;
-			case  4:
-				CurBot->Level = tmpInt;
-				break;
-			case  5:
-				CurBot->ClassID = tmpInt;
-				break;
-			case  6:
-				CurBot->LifeCur = tmpInt;
-				break;
-			case  7:
-				CurBot->LifeMax = tmpInt;
-				break;
-			case  8:
-				CurBot->EnduCur = tmpInt;
-				break;
-			case  9:
-				CurBot->EnduMax = tmpInt;
-				break;
-			case 10:
-				CurBot->ManaCur = tmpInt;
-				break;
-			case 11:
-				CurBot->ManaMax = tmpInt;
-				break;
-			case 12:
-				CurBot->PetID = tmpInt;
-				break;
-			case 13:
-				CurBot->PetHP = tmpInt;
-				break;
-			case 14:
-				CurBot->TargetID = tmpInt;
-				break;
-			case 15:
-				CurBot->TargetHP = tmpInt;
-				break;
-			case 16:
-				CurBot->CastID = tmpInt;
-				break;
-			case 17:
-				CurBot->State = (WORD)tmpInt;
-				break;
-			case 18:
-				CurBot->XP = (DWORD)tmpInt;
-				break;
-			case 19:
-				CurBot->aaXP = (DWORD)tmpInt;
-				break;
-#if HAS_LEADERSHIP_EXPERIENCE
-			case 20:
-				CurBot->glXP = GetDoubleFromString(pValues->Value, 0.0);
-				break;
-#endif
-			case 21:
-				CurBot->FreeBuff = tmpInt;
-				break;
-			case 22:
-				strcpy_s(CurBot->Leader, pValues->Value.c_str());
-				break;
-			//      case 30: InfoGems(pValues->Value);                      break;
-			case 31:
-				InfoBuff(CurBot, pValues->Value.c_str());
-				break;
-			case 32:
-				InfoSong(CurBot, pValues->Value.c_str());
-				break;
-			case 33:
-				InfoPets(CurBot, pValues->Value.c_str());
-				break;
-			//      case 34: InfoDura(pValues->Value);                     break;
-			case 35:
-				CurBot->TotalAA = tmpInt;
-				break;
-			case 36:
-				CurBot->UsedAA = tmpInt;
-				break;
-			case 37:
-				CurBot->UnusedAA = tmpInt;
-				break;
-			case 38:
-				CurBot->CombatState = tmpInt;
-				break;
-			case 39:
-				strcpy_s(CurBot->Note, pValues->Value.c_str());
-				break;
-			case 40:
-				InfoDetr(CurBot, pValues->Value.c_str());
-				break;
-			case 89:
-				strcpy_s(CurBot->Location, pValues->Value.c_str());
-				break;
-			case 90:
-				strcpy_s(CurBot->Heading, pValues->Value.c_str());
-				break;
-			default:
-				break;
-		}
-		pValues = pValues->pNext;
+void InfoFreeI(BotInfo* botInfo, const char* Line) {
+	char szTemp[MAX_STRING];
+	for (int i = 0; i < ISIZE; i++) {
+		GetArg(szTemp, Line, i + 1, FALSE, FALSE, FALSE, ':');
+		botInfo->FreeInventory[i] = GetIntFromString(szTemp, 0);
 	}
 }
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
 
-/*
-PSTR MakeDURAS(CHAR(&Buffer)[_Size]) {
-  long Duration; char tmp[MAX_STRING]; Buffer[0]=0;
-  for(int b=0; b<BUFF_MAX; b++)
-	if((Duration=GetCharInfo2()->Buff[b].Duration)>0) {
-	  sprintf_s(tmp,"%d:",Duration);
-//     WriteChatf("Spell %d:%d", GetCharInfo2()->Buff[b].SpellID, GetCharInfo2()->Buff[b].Duration );
-	  strcat_s(Buffer,tmp);
-	}
-
-  return Buffer;
+bool Evaluate(const char* expression) {
+	char szTemp[MAX_STRING] = { 0 };
+	strcpy_s(szTemp, expression);
+	ParseMacroData(szTemp, sizeof(szTemp));
+	return GetIntFromString(szTemp, 0) != 0;
 }
-*/
 
-template <unsigned int _Size>
-PSTR MakeBUFFS(CHAR(&Buffer)[_Size]) {
-	long SpellID; char tmp[MAX_STRING] = { 0 }; Buffer[0] = '\0';
-	for (int b = 0; b < BUFF_MAX; b++)
-		if ((SpellID = GetPcProfile()->GetEffect(b).SpellID) > 0) {
-			sprintf_s(tmp, "%d:", SpellID);
-			strcat_s(Buffer, tmp);
+int GetAARankByName(const char* AAName) {
+	int level = pLocalPlayer->Level;
+	for (int nAbility = 0; nAbility < AA_CHAR_MAX_REAL; nAbility++) {
+		if (CAltAbilityData* pAbility = GetAAById(pLocalPC->GetAlternateAbilityId(nAbility), level)) {
+			if (const char* pName = pCDBStr->GetString(pAbility->nName, eAltAbilityName)) {
+				if (!_stricmp(AAName, pName)) {
+					int CurrentRank = pAbility->CurrentRank - 1;
+					if (pLocalPC->HasAlternateAbility(pAbility->Index)) {
+						CurrentRank++;
+					}
+					return CurrentRank;
+				}
+			}
 		}
-	if (strlen(Buffer)) {
-		sprintf_s(tmp, "|F=${Me.FreeBuffSlots}");
-		ParseMacroData(tmp, sizeof(tmp));
-		strcat_s(Buffer, tmp);
 	}
+	return 0;
+}
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
+
+template <unsigned int _Size>char* MakeBUFFS(char(&Buffer)[_Size]) {
+	strcpy_s(Buffer, bBuffs);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeCASTD(CHAR(&Buffer)[_Size]) {
-	long Casting = GetCharInfo()->pSpawn->CastingData.SpellID;
-	if (Casting > 0)
-		_itoa_s(Casting, Buffer, 10);
-	else
+template <unsigned int _Size>char* MakeBUFFD(char(&Buffer)[_Size]) {
+	if (NetExtended >= EX_GEMS_AND_BUFF_DURATIONS) { 
+		strcpy_s(Buffer, bBuffd);
+	} else {
 		Buffer[0] = 0;
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakeHEADN(CHAR(&Buffer)[_Size]) {
-	if (strlen(Buffer)) {
-		sprintf_s(Buffer, "%4.2f", GetCharInfo()->pSpawn->Heading);
 	}
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeLOCAT(CHAR(&Buffer)[_Size]) {
-	if (strlen(Buffer)) {
-		sprintf_s(Buffer, "%4.2f:%4.2f:%4.2f:%d", GetCharInfo()->pSpawn->Y, GetCharInfo()->pSpawn->X, GetCharInfo()->pSpawn->Z, GetCharInfo()->pSpawn->Animation);
+template <unsigned int _Size>char* MakeSONGS(char(&Buffer)[_Size]) {
+	strcpy_s(Buffer, bSongs);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeSONGD(char(&Buffer)[_Size]) {
+	if (NetExtended >= EX_SONG_DURATIONS) { 
+		strcpy_s(Buffer, bSongd);
+	} else {
+		Buffer[0] = 0;
 	}
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeENDUS(CHAR(&Buffer)[_Size]) {
-	if (long EnduMax = GetMaxEndurance()) sprintf_s(Buffer, "%d/%d", GetPcProfile()->Endurance, EnduMax);
-	else strcpy_s(Buffer, "/");
+template <unsigned int _Size>char* MakePBUFF(char(&Buffer)[_Size]) {
+	strcpy_s(Buffer, bPBuffs);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeEXPER(CHAR(&Buffer)[_Size]) {
+template <unsigned int _Size>char* MakePETD(char(&Buffer)[_Size]) {
+	if (NetExtended >= EX_PET_DURATIONS) { 
+		strcpy_s(Buffer, bPBuffd);
+	} else {
+		Buffer[0] = 0;
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeFREEB(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%d", AvailBuffSlots);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeCASTD(char(&Buffer)[_Size]) {
+	int Casting = pLocalPlayer->CastingData.SpellID;
+	if (Casting > 0) {
+		sprintf_s(Buffer, "%d", Casting);
+	} else {
+		Buffer[0] = 0;
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeHEADN(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%4.2f", pLocalPlayer->Heading);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeLOCAT(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%4.2f:%4.2f:%4.2f:%d", pLocalPlayer->Y, pLocalPlayer->X, pLocalPlayer->Z, pLocalPlayer->Animation);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeENDUS(char(&Buffer)[_Size]) {
+	if (int Max = GetMaxEndurance()) {
+		sprintf_s(Buffer, "%d/%d", GetCurEndurance(), Max);
+	} else {
+		strcpy_s(Buffer, "/");
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeMACRO(char(&Buffer)[_Size]) {
+	int Status = MACRO_NONE;
+	if (gszMacroName[0]) {
+		Status = MACRO_RUNNING;
+		if (MQMacroBlockPtr pBlock = GetCurrentMacroBlock()) {
+			if (pBlock->Paused) {
+				Status = MACRO_PAUSED;
+			}
+		}
+		sprintf_s(Buffer, "%d:%s", Status, gszMacroName);
+	} else {
+		sprintf_s(Buffer, "%d:", Status);
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeEXPER(char(&Buffer)[_Size]) {
 #if HAS_LEADERSHIP_EXPERIENCE
-	sprintf_s(Buffer, "%I64d:%d:%02.3f", GetCharInfo()->Exp, GetCharInfo()->AAExp, GetCharInfo()->GroupLeadershipExp);
+	sprintf_s(Buffer, "%I64d:%d:%02.3f", pLocalPC->Exp, pLocalPC->AAExp, pLocalPC->GroupLeadershipExp);
 #else
-	sprintf_s(Buffer, "%I64d:%d", GetCharInfo()->Exp, GetCharInfo()->AAExp);
+	sprintf_s(Buffer, "%I64d:%d", pLocalPC->Exp, pLocalPC->AAExp);
 #endif
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeLEADR(CHAR(&Buffer)[_Size]) {
-	if (auto pChar = GetCharInfo()) {
-		if (pChar->pGroupInfo && pChar->pGroupInfo->pLeader && !pChar->pGroupInfo->pLeader->Name.empty()) {
-			strcpy_s(Buffer, pChar->pGroupInfo->pLeader->Name.c_str());
-		}
-		else {
-			Buffer[0] = 0;
-		}
-		return Buffer;
-	}
-	else {
-		Buffer[0] = 0;
+template <unsigned int _Size>char* MakeLEADR(char(&Buffer)[_Size]) {
+	Buffer[0] = 0;
+	if (pLocalPC && pLocalPC->Group && pLocalPC->Group->GetGroupLeader()) {
+		strcpy_s(Buffer, pLocalPC->Group->GetGroupLeader()->GetName());
 	}
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeNOTE(CHAR(&Buffer)[_Size]) {
+template <unsigned int _Size>char* MakeNOTE(char(&Buffer)[_Size]) {
 	strcpy_s(Buffer, NetNote);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeLEVEL(CHAR(&Buffer)[_Size]) {
+template <unsigned int _Size>char* MakeLEVEL(char(&Buffer)[_Size]) {
 	sprintf_s(Buffer, "%d:%d", GetPcProfile()->Level, GetPcProfile()->Class);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeLIFES(CHAR(&Buffer)[_Size]) {
+template <unsigned int _Size>char* MakeHPS(char(&Buffer)[_Size]) {
 	sprintf_s(Buffer, "%d/%d", GetCurHPS(), GetMaxHPS());
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeMANAS(CHAR(&Buffer)[_Size]) {
-	if (long ManaMax = GetMaxMana()) sprintf_s(Buffer, "%d/%d", GetPcProfile()->Mana, ManaMax);
-	else strcpy_s(Buffer, "/");
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakePBUFF(CHAR(&Buffer)[_Size]) {
-	Buffer[0] = '\0';
-	auto Pet = GetSpawnByID(pLocalPlayer->PetID);
-	if (Pet && pPetInfoWnd)
-	{
-		// SpellID is an int, so the longest is probably 11.
-		char tmp[20] = { 0 };
-		for (int b = 0; b < pPetInfoWnd->GetMaxBuffs(); b++)
-		{
-			int SpellID = pPetInfoWnd->GetBuff(b);
-			if (SpellID > 0) {
-				sprintf_s(tmp, "%d:", SpellID);
-				strcat_s(Buffer, tmp);
-			}
-		}
+template <unsigned int _Size>char* MakeMANAS(char(&Buffer)[_Size]) {
+	if (int Max = GetMaxMana()) {
+		sprintf_s(Buffer, "%d/%d", GetCurMana(), Max);
+	} else {
+		strcpy_s(Buffer, "/");
 	}
-	//  WriteChatf("MakePBUFF: [%s]", Buffer);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakePETIL(CHAR(&Buffer)[_Size]) {
-	auto Pet = (PSPAWNINFO)GetSpawnByID(GetCharInfo()->pSpawn->PetID);
-	if (pPetInfoWnd && Pet) {
-		sprintf_s(Buffer, "%d:%d", Pet->SpawnID,
-			static_cast<int32_t>(Pet->HPCurrent * 100 / Pet->HPMax));
+template <unsigned int _Size>char* MakePETIL(char(&Buffer)[_Size]) {
+	auto Pet = GetSpawnByID(pLocalPlayer->PetID);
+	if (Pet && pPetInfoWnd) {
+		sprintf_s(Buffer, "%d:%d", Pet->SpawnID, static_cast<int32_t>(Pet->HPMax == 0 ? 0 : Pet->HPCurrent * 100 / Pet->HPMax));
 	} else {
 		strcpy_s(Buffer, ":");
 	}
 	return Buffer;
 }
 
-/*
-PSTR MakeSPGEM(CHAR(&Buffer)[_Size]) {
-  long SpellID; char tmp[32]; Buffer[0]=0;
-  for(int g=0; g<GEMS_MAX; g++)
-	if((SpellID=(pCastSpellWnd && GetMaxMana()>0)?GetCharInfo2()->MemorizedSpells[g]:0)>0) {
-	  sprintf_s(tmp,"%d:",SpellID);
-	  strcat_s(Buffer,tmp);
-	}
-  return Buffer;
-}
-*/
-
-template <unsigned int _Size>PSTR MakeSONGS(CHAR(&Buffer)[_Size]) {
-	long SpellID = 0; char tmp[MAX_STRING] = { 0 }; Buffer[0] = '\0';
-	for (int b = 0; b < NUM_TEMP_BUFFS; b++)
-		if ((SpellID = GetPcProfile()->GetTempEffect(b).SpellID) > 0) {
-			sprintf_s(tmp, "%d:", SpellID);
-			strcat_s(Buffer, tmp);
+template <unsigned int _Size>char* MakeSPGEM(char(&Buffer)[_Size]) {
+	Buffer[0] = '\0';
+	if (NetExtended >= EX_GEMS_AND_BUFF_DURATIONS) {
+		char szTemp[MAX_STRING] = { 0 };
+		for (int i = 0; i < NUM_SPELL_GEMS; i++) {
+			if (auto pSpell = GetSpellByID(GetMemorizedSpell(i))) {
+				sprintf_s(szTemp, "%d:", pSpell->ID);
+	  			strcat_s(Buffer, szTemp);
+			}
+			else {
+				strcat_s(Buffer,"0:");
+			}
 		}
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakeSTATE(CHAR(&Buffer)[_Size]) {
-	WORD Status = 0;
-	if (pEverQuestInfo->bAutoAttack)                       Status |= STATE_ATTACK;
-	if (pRaid && pRaid->RaidMemberCount)                   Status |= STATE_RAID;
-	if (pLocalPC->Stunned)                                 Status |= STATE_STUN;
-	if (pLocalPC->pGroupInfo)                              Status |= STATE_GROUP;
-	if (FindSpeed(pLocalPC->pSpawn))                       Status |= STATE_MOVING;
-	if (pLocalPC->pSpawn->Mount)                           Status |= STATE_MOUNT;
-	if (pLocalPC->pSpawn->AFK)                             Status |= STATE_AFK;
-	if (pLocalPC->pSpawn->HideMode)                        Status |= STATE_INVIS;
-	if (pLocalPC->pSpawn->mPlayerPhysicsClient.Levitate)   Status |= STATE_LEV;
-	if (pLocalPC->pSpawn->LFG)                             Status |= STATE_LFG;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_DEAD)   Status |= STATE_DEAD;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_FEIGN)  Status |= STATE_FEIGN;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_DUCK)   Status |= STATE_DUCK;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_BIND)   Status |= STATE_BIND;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_STAND)  Status |= STATE_STAND;
-	if (pLocalPC->pSpawn->StandState == STANDSTATE_SIT)    Status |= STATE_SIT;
-	_itoa_s(Status, Buffer, 10);
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakeOOCST(CHAR(&Buffer)[_Size]) {
-	_itoa_s(pPlayerWnd->CombatState, Buffer, 10);
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakeAAPTS(CHAR(&Buffer)[_Size]) {
-	sprintf_s(Buffer, "%d:%d:%d", GetPcProfile()->AAPoints + GetPcProfile()->AAPointsSpent, GetPcProfile()->AAPointsSpent, GetPcProfile()->AAPoints);
-	return Buffer;
-}
-
-template <unsigned int _Size>PSTR MakeTARGT(CHAR(&Buffer)[_Size]) {
-	auto Tar = pTarget ? ((PSPAWNINFO)pTarget) : NULL;
-	if (Tar) {
-		sprintf_s(Buffer, "%d:%d", Tar->SpawnID,
-			static_cast<int32_t>(Tar->HPCurrent * 100 / Tar->HPMax));
 	}
-	else {
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeBSTAT(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%u:%u", detrStatus, beneStatus);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeSTATE(char(&Buffer)[_Size]) {
+	uint32_t Status = 0;
+	if (pEverQuestInfo->bAutoAttack) {
+		Status |= STATE_ATTACK;
+	}
+	if (pEverQuestInfo->bAutoRangeAttack) {
+		Status |= STATE_RANGED;
+	}
+	if (pRaid && pRaid->RaidMemberCount) {
+		Status |= STATE_RAID;
+	}
+	if (pLocalPlayer->PlayerState & 0x20) {
+		Status |= STATE_STUN;
+	}
+	if (pLocalPC->pGroupInfo) {
+		Status |= STATE_GROUP;
+	}
+	if (fabs(pLocalPlayer->SpeedRun) > 0.0f) {
+		Status |= STATE_MOVING;
+	}
+	if (pLocalPlayer->Mount) {
+		Status |= STATE_MOUNT;
+	}
+	if (pLocalPlayer->AFK) {
+		Status |= STATE_AFK;
+	}
+	if ((pLocalPlayer->HideMode & 0x01) ||
+		(invisStatus & INVIS_NORMAL)) {
+		Status |= STATE_INVIS;
+	}
+	if (invisStatus & INVIS_UNDEAD) {
+		Status |= STATE_ITU;
+	}
+	if (pLocalPlayer->mPlayerPhysicsClient.Levitate == 2) {
+		Status |= STATE_LEV;
+	}
+	if (pLocalPlayer->LFG) {
+		Status |= STATE_LFG;
+	}
+	if (pLocalPlayer->RespawnTimer != 0) {
+		Status |= STATE_HOVER;
+	}
+	switch (pLocalPlayer->StandState) {
+		case STANDSTATE_STAND:
+			Status |= STATE_STAND;
+			break;
+		case STANDSTATE_SIT:
+			Status |= STATE_SIT;
+			break;
+		case STANDSTATE_DUCK:
+			Status |= STATE_DUCK;
+			break;
+		case STANDSTATE_BIND:
+			Status |= STATE_BIND;
+			break;
+		case STANDSTATE_FEIGN:
+			Status |= STATE_FEIGN;
+			break;
+		case STANDSTATE_DEAD:
+			Status |= STATE_DEAD;
+			break;
+		default:
+			break;
+	}
+	if (pTarget && pLocalPlayer->TargetOfTarget == pLocalPlayer->GetId()) {
+		if (GetSpawnType(pTarget) == NPC) {
+			Status |= STATE_HAVEAGGRO;
+		}
+	}
+	if (int i = IsPluginLoaded("MQ2Melee") ? Evaluate("${If[${Melee.AggroMode},1,0]}") : 0) {
+		Status |= STATE_WANTAGGRO;
+	}
+	if (IsPluginLoaded("MQ2Nav")) {
+		if (Evaluate("${If[${Navigation.Active},1,0]}")) {
+			Status |= STATE_NAVACTIVE;
+		}
+		if (Evaluate("${If[${Navigation.Paused},1,0]}")) {
+			Status |= STATE_NAVPAUSED;
+		}
+	}
+	if (int i = IsPluginLoaded("MQ2Bot") ? Evaluate("${If[${Bot.Active},1,0]}") : 0) {
+		Status |= STATE_BOTACTIVE;
+	}
+	if (int Rank = GetAARankByName(PetAAName)) {
+		if (Rank >= PetAARank) {
+			Status |= STATE_HASPETAA;
+		}
+	}
+	sprintf_s(Buffer, "%u", Status);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeOOCST(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%d", GetCombatState());
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeAAPTS(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%d:%d:%d", GetPcProfile()->AAPoints, GetPcProfile()->AAPointsSpent, GetPcProfile()->AAPointsAssigned[0]);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeTARGT(char(&Buffer)[_Size]) {
+	if (pTarget) {
+		sprintf_s(Buffer, "%d:%d", pTarget->SpawnID, static_cast<int32_t>(pTarget->HPMax == 0 ? 0 : pTarget->HPCurrent * 100 / pTarget->HPMax));
+	} else {
 		strcpy_s(Buffer, ":");
 	}
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeZONES(CHAR(&Buffer)[_Size]) {
-	sprintf_s(Buffer, "%d:%d>%d", GetCharInfo()->zoneId, GetCharInfo()->instance, GetCharInfo()->pSpawn->SpawnID);
+template <unsigned int _Size>char* MakeZONES(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%d:%d>%d", pLocalPC->zoneId, pLocalPC->instance, pLocalPlayer->SpawnID);
 	return Buffer;
 }
 
-template <unsigned int _Size>PSTR MakeDETR(CHAR(&Buffer)[_Size]) {
-	char tmp[MAX_STRING]; Buffer[0] = 0;
-	ZeroMemory(&dValues, sizeof(dValues));
-	for (int b = 0; b < BUFF_MAX; b++) {
-		if (auto spell = GetSpellByID(GetPcProfile()->GetEffect(b).SpellID)) {
-			if (!spell->SpellType) {
-				bool d = false;
-				bool r = false;
-				for (int s = 0; s < GetSpellNumEffects(spell); s++) switch (GetSpellAttrib(spell, s)) {
-				case   0: if (GetSpellBase(spell, s) < 0) { dValues[LIFEDRAIN] += SlotCalculate(spell, s); d = true; } break;
-				case   3: if (GetSpellBase(spell, s) < 0) { dValues[SNARED]++; d = true; } break;
-				case  11: if (((GetSpellMax(spell, s)) ? GetSpellMax(spell, s) : GetSpellBase(spell, s)) - 100 < 0) { dValues[SLOWED]++; d = true; } break;
-				case  15: if (GetSpellBase(spell, s) < 0) { dValues[MANADRAIN] += SlotCalculate(spell, s); d = true; } break;
-				case  20: dValues[BLINDED]++; d = true; break;
-				case  22: dValues[CHARMED]++;  d = true; break;
-				case  23: dValues[FEARED]++; d = true; break;
-				case  31: dValues[MESMERIZED]++; d = true; break;
-				case  35: dValues[DISEASED] += (int)GetSpellBase(spell, s); d = true; break;
-				case  36: dValues[POISONED] += (int)GetSpellBase(spell, s); d = true; break;
-				case  40: dValues[INVULNERABLE]++; d = true; break;
-				case  46: if (GetSpellBase(spell, s) < 0) { r = true; d = true; } break;
-				case  47: if (GetSpellBase(spell, s) < 0) { r = true; d = true; } break;
-				case  48: if (GetSpellBase(spell, s) < 0) { r = true; d = true; } break;
-				case  49: if (GetSpellBase(spell, s) < 0) { r = true; d = true; } break;
-				case  50: if (GetSpellBase(spell, s) < 0) { r = true; d = true; } break;
-				case  96: dValues[SILENCED]++; d = true; break;
-				case  99: dValues[ROOTED]++; d = true; break;
-				case 112: if (GetSpellBase(spell, s) < 0) { dValues[CASTINGLEVEL]++; d = true; } break;
-				case 116: dValues[CURSED] += (int)GetSpellBase(spell, s); d = true; break;
-				case 120: if (GetSpellBase(spell, s) < 0) { dValues[HEALING]++; d = true; } break;
-				case 124: if (GetSpellBase(spell, s) < 0) { dValues[SPELLDAMAGE]++; d = true; } break;
-				case 127: if (GetSpellBase(spell, s) < 0) { dValues[SPELLSLOWED]++; d = true; } break;
-				case 132: if (GetSpellBase(spell, s) < 0) { dValues[SPELLCOST]++; d = true; } break;
-				case 189: if (GetSpellBase(spell, s) < 0) { dValues[ENDUDRAIN] += SlotCalculate(spell, s); d = true; } break;
-				case 289: dValues[TRIGGR]++; d = true; break;
-				case 369: dValues[CORRUPTED] += (int)GetSpellBase(spell, s); d = true; break;
+template <unsigned int _Size>char* MakeDETR(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING];
+	Buffer[0] = 0;
+	for (int i = 0; i < DSIZE; i++) {
+		sprintf_s(szTemp, "%lld:", dValues[i]);
+		strcat_s(Buffer, szTemp);
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeFREEI(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING];
+	Buffer[0] = 0;
+	int freeSlots[ISIZE] = { 0 };
+	int slotMax = ISIZE - 1;
+	for (int slot = InvSlot_FirstBagSlot; slot <= GetHighestAvailableBagSlot(); slot++) {
+		if (ItemPtr pItem = GetPcProfile()->InventoryContainer.GetItem(slot)) {
+			if (pItem->IsContainer()) {
+				int iSize = std::clamp((int)pItem->GetItemDefinition()->SizeCapacity, 0, slotMax);
+				freeSlots[iSize] += pItem->GetHeldItems().GetSize() - pItem->GetHeldItems().GetCount();
+			}
+		} else {
+			freeSlots[slotMax]++;
+		}
+	}
+	for (int slot = slotMax; slot > 0; slot--) {
+		freeSlots[slot - 1] += freeSlots[slot];
+	}
+	for (int i = 0; i < ISIZE; i++) {
+		sprintf_s(szTemp, "%d:", freeSlots[i]);
+		strcat_s(Buffer, szTemp);
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeVERSN(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%.2f", MQ2Version);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeEXTEND(char(&Buffer)[_Size]) {
+	sprintf_s(Buffer, "%d", NetExtended);
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeCAMPS(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING];
+	if (IsPluginLoaded("MQ2MoveUtils")) {
+		strcpy_s(szTemp, "${Select[${MakeCamp.Status},ON,PAUSED]}:${MakeCamp.AnchorX}:${MakeCamp.AnchorY}:${MakeCamp.CampRadius}:${MakeCamp.CampDist}");
+		ParseMacroData(szTemp, sizeof(szTemp));
+		strcpy_s(Buffer, szTemp);
+	} else {
+		strcpy_s(Buffer, "0:0:0:0:0");
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeLUA(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING] = { 0 };
+	char szScriptName[MAX_STRING] = { 0 };
+	char* token = NULL;
+	char* next_token = NULL;
+	Buffer[0] = '\0';
+	if (IsPluginLoaded("Lua")) {
+		strcpy_s(szTemp, "${Lua.PIDs}");
+		ParseMacroData(szTemp, sizeof(szTemp));
+		token = strtok_s(szTemp, ",", &next_token);
+		while (token != NULL) {
+			sprintf_s(szScriptName, "${Lua.Script[%s].Name}", token);
+			ParseMacroData(szScriptName, sizeof(szScriptName));
+			if (szScriptName[0] && _stricmp(szScriptName, "NULL")) {
+				if (strlen(Buffer)) {
+					strcat_s(Buffer, ",");
 				}
-				if (d) {
-					dValues[DETRIMENTALS]++;
-					switch (spell->ID) {
-					case 45473:  /* Putrid Infection is curable, but missing WearOff message */
-						break;
-					default:
-						/*CastByMe,CastByOther,CastOnYou,CastOnAnother,WearOff*/
-						if ((spell->IsNoDispell() && GetSpellString(spell->ID, 4) != nullptr) || spell->TargetType == 6) dValues[NOCURE]++;
-						break;
+				strcat_s(Buffer, szScriptName);
+			}
+			token = strtok_s(NULL, ",", &next_token);
+		}
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeEQBC(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING];
+	if (NetEQBCData && IsPluginLoaded("MQ2EQBC")) {
+		strcpy_s(szTemp, "${EQBC.Packets}:${EQBC.HeartBeat}");
+		ParseMacroData(szTemp, sizeof(szTemp));
+		strcpy_s(Buffer, szTemp);
+	} else {
+		strcpy_s(Buffer, "0:0");
+	}
+	return Buffer;
+}
+
+template <unsigned int _Size>char* MakeQUERY(char(&Buffer)[_Size]) {
+	char szTemp[MAX_STRING] = { 0 };
+	strcpy_s(szTemp, NetQuery);
+	ParseMacroData(szTemp, sizeof(szTemp));
+	strcpy_s(Buffer, szTemp);
+	return Buffer;
+}
+
+int SlotCalculate(EQ_Spell* spell, int slot) {
+	char szTemp[MAX_STRING] = { 0 };
+	SlotValueCalculate(szTemp, spell, slot, 1);
+	return GetIntFromString(szTemp, 0);
+}
+
+unsigned int SpellClassMask(std::initializer_list<int> classlist) {
+	unsigned int mask = 0;
+	for (int num : classlist) {
+		mask |= (1 << num);
+	}
+	return mask;
+}
+
+void EvalDetrimental(EQ_Spell* spell) {
+	bool detr = false;
+	bool counter = false;
+	int subcat = GetSpellSubcategory(spell);
+	int attrib = 0;
+	int64_t base = 0;
+	for (int s = 0; s < GetSpellNumEffects(spell); s++) {
+		attrib = GetSpellAttrib(spell, s);
+		base   = GetSpellBase(spell, s);
+		switch (attrib) {
+			case SPA_CHA:
+				break;
+			case SPA_HP:
+				if (base < 0) {
+					detrStatus |= BD_LIFEDRAIN;
+					dValues[D_LIFEDRAIN] += SlotCalculate(spell, s);
+					detr = true;
+				}
+				break;
+			case SPA_MOVEMENT_RATE:
+				if (base < 0) {
+					detrStatus |= BD_SNARED;
+					detr = true;
+				}
+				break;
+			case SPA_HASTE:
+				if (base < 100) {
+					detrStatus |= BD_SLOWED;
+					detr = true;
+				}
+				break;
+			case SPA_MANA:
+				if (base < 0) {
+					detrStatus |= BD_MANADRAIN;
+					dValues[D_MANADRAIN] += SlotCalculate(spell, s);
+					detr = true;
+				}
+				break;
+			case SPA_BLINDNESS:
+				detrStatus |= BD_BLINDED;
+				detr = true;
+				break;
+			case SPA_CHARM:
+				detrStatus |= BD_CHARMED;
+				detr = true;
+				break;
+			case SPA_FEAR:
+				detrStatus |= BD_FEARED;
+				detr = true;
+				break;
+			case SPA_ENTHRALL:
+				detrStatus |= BD_MESMERIZED;
+				detr = true;
+				break;
+			case SPA_DISEASE:
+				detrStatus |= BD_DISEASED;
+				detr = true;
+				counter = true;
+				break;	
+			case SPA_POISON:
+				detrStatus |= BD_POISONED;
+				detr = true;
+				counter = true;
+				break;
+			case SPA_INVULNERABILITY:
+				detrStatus |= BD_INVULNERABLE;
+				detr = true;
+				break;
+			case SPA_RESIST_FIRE:
+			case SPA_RESIST_COLD:
+			case SPA_RESIST_POISON:
+			case SPA_RESIST_DISEASE:
+			case SPA_RESIST_MAGIC:
+			case SPA_RESIST_CORRUPTION:
+			case SPA_RESIST_ALL:
+				if (base < 0) {
+					detrStatus |= BD_RESISTANCE;
+					detr = true;
+				}
+				break;
+			case SPA_SILENCE:
+				detrStatus |= BD_SILENCED;
+				detr = true;
+				break;
+			case SPA_ROOT:
+				detrStatus |= BD_ROOTED;
+				detr = true;
+				break;
+			case SPA_FIZZLE_SKILL:
+				if (base < 0) {
+					detrStatus |= BD_CASTINGLEVEL;
+					detr = true;
+				}
+				break;
+			case SPA_CURSE:
+				detrStatus |= BD_CURSED;
+				detr = true;
+				counter = true;
+				break;
+			case SPA_HEALMOD:
+				if (base < 0) {
+					detrStatus |= BD_HEALING;
+					detr = true;
+				}
+				break;
+			case SPA_IRONMAIDEN:
+				if (base < 0) {
+					detrStatus |= BD_REVDSED;
+					detr = true;
+				}
+				break;
+			case SPA_FOCUS_DAMAGE_MOD:
+				if (base < 0) {
+					detrStatus |= BD_SPELLDAMAGE;
+					detr = true;
+				}
+				break;
+			case SPA_FOCUS_CAST_TIME_MOD:
+				if (base < 0) {
+					detrStatus |= BD_SPELLSLOWED;
+					detr = true;
+				}
+				break;
+			case SPA_FOCUS_MANACOST_MOD:
+				if (base < 0) {
+					detrStatus |= BD_SPELLCOST;
+					detr = true;
+				}
+				break;
+			case SPA_ENDURANCE:
+				if (base < 0) {
+					detrStatus |= BD_ENDUDRAIN;
+					dValues[D_ENDUDRAIN] += SlotCalculate(spell, s);
+					detr = true;
+				}
+				break;
+			case SPA_DOOM_EFFECT:
+				detrStatus |= BD_TRIGGER;
+				detr = true;
+				break;
+			case SPA_CORRUPTION:
+				detrStatus |= BD_CORRUPTED;
+				detr = true;
+				counter = true;
+				break;
+			default:
+				detr = true;
+				break;
+		}
+	}
+	switch (subcat) {
+		case SPELLCAT_DISEMPOWERING:
+			detrStatus |= BD_CRIPPLED;
+			detr = true;
+			break;
+		case SPELLCAT_RESIST_DEBUFFS:
+			if (IsSpellUsableForClass(spell, SpellClassMask({ Shaman, Mage }))) {
+				detrStatus |= BD_MALOED;
+				detr = true;
+			} else if (IsSpellUsableForClass(spell, SpellClassMask({ Enchanter }))) {
+				detrStatus |= BD_TASHED;
+				detr = true;
+			}
+			break;
+		default:
+			break;
+	}
+	if (detr) {
+		dValues[D_DETRIMENTALS]++;
+		if ((spell->IsNoDispell() && !counter) || spell->TargetType == TargetType_Self) {
+			dValues[D_NOCURE]++;
+		}
+	}
+}
+
+void EvalBeneficial(EQ_Spell* spell) {
+	int cat = GetSpellCategory(spell);
+	int subcat = GetSpellSubcategory(spell);
+	int attrib = 0;
+	int64_t base = 0;
+	for (int s = 0; s < GetSpellNumEffects(spell); s++) {
+		attrib = GetSpellAttrib(spell, s);
+		base   = GetSpellBase(spell, s);
+		switch (attrib) {
+			case SPA_CHA:
+				break;
+			case SPA_HP:
+				if (base > 0) {
+					beneStatus |= BB_REGEN;
+				}
+				break;
+			case SPA_HASTE:
+				if (base > 100) {
+					beneStatus |= BB_HASTED;
+				}
+				break;
+			case SPA_MANA:
+				if (base > 0) {
+					if (IsSpellUsableForClass(spell, SpellClassMask({ Enchanter }))) {
+						beneStatus |= BB_CLARITY;
 					}
 				}
-				if (r) dValues[RESISTANCE]++;
+				break;
+			case SPA_DAMAGE_SHIELD:
+				if (base < 0) {
+					beneStatus |= BB_DSED;
+				}
+				break;
+			case SPA_AC:
+				if (base > 0) {
+					if (cat == SPELLCAT_HP_BUFFS &&
+						subcat == SPELLCAT_AEGOLISM &&
+						IsSpellUsableForClass(spell, SpellClassMask({ Cleric }))) {
+						beneStatus |= BB_AEGO;
+					}
+				}
+				break;
+			case SPA_MELEE_GUARD:
+				if (cat == SPELLCAT_UTILITY_BENEFICIAL &&
+					subcat == SPELLCAT_MELEE_GUARD &&
+					IsSpellUsableForClass(spell, SpellClassMask({ Cleric }))) {
+					beneStatus |= BB_SHINING;
+				}
+				break;
+			case SPA_INVISIBILITY:
+			case SPA_IMPROVED_INVIS:
+				invisStatus |= INVIS_NORMAL;
+				break;
+			case SPA_INVIS_VS_UNDEAD:
+			case SPA_IMPROVED_INVIS_UNDEAD:
+				invisStatus |= INVIS_UNDEAD;
+				break;
+			default:
+				break;
+		}
+	}
+	switch (cat) {
+		case SPELLCAT_HP_BUFFS:
+			switch (subcat) {
+				case SPELLCAT_HP_TYPE_ONE:
+					if (IsSpellUsableForClass(spell,SpellClassMask({ Druid }))) {
+						beneStatus |= BB_SKIN;
+					} else if (IsSpellUsableForClass(spell, SpellClassMask({ Ranger }))) {
+						beneStatus |= BB_HYBRIDHP;
+					}
+					break;
+				case SPELLCAT_HP_TYPE_TWO:
+					if (IsSpellUsableForClass(spell, SpellClassMask({ Ranger }))) {
+						beneStatus |= BB_STRENGTH;
+					} else if (IsSpellUsableForClass(spell, SpellClassMask({ Paladin }))) {
+						beneStatus |= BB_BRELLS;
+					} else if (IsSpellUsableForClass(spell, SpellClassMask({ Beastlord }))) {
+						beneStatus |= BB_SV;
+					}
+					break;
+				case SPELLCAT_TEMPORARY:
+					if (IsSpellUsableForClass(spell, SpellClassMask({ Druid }))) {
+						beneStatus |= BB_GROWTH;
+					}
+					break;
+				case SPELLCAT_SYMBOL:
+					if (IsSpellUsableForClass(spell, SpellClassMask({ Cleric }))) {
+						beneStatus |= BB_SYMBOL;
+					}
+					break;
+				case SPELLCAT_SHIELDING:
+					if (IsSpellUsableForClass(spell, SpellClassMask({ Shaman }))) {
+						beneStatus |= BB_FOCUS;
+					}
+					break;
+				default:
+					break;
+			}
+			break;
+		case SPELLCAT_STATISTIC_BUFFS:
+			if (subcat == SPELLCAT_ATTACK && IsSpellUsableForClass(spell, SpellClassMask({ Ranger }))) {
+				beneStatus |= BB_PRED;
+			}
+			break;
+		case SPELLCAT_REGEN:
+			if (subcat == SPELLCAT_HEALTH_MANA && IsSpellUsableForClass(spell, SpellClassMask({ Beastlord }))) {
+				beneStatus |= BB_SE;
+			}
+			break;
+		case SPELLCAT_UTILITY_BENEFICIAL:
+			if (subcat == SPELLCAT_MELEE_GUARD && IsSpellUsableForClass(spell, SpellClassMask({ Ranger }))) {
+				beneStatus |= BB_PRED;
+			}
+			break;
+		default:
+			break;
+	}
+}
+
+void ScanBuffs() {
+	char szTemp[MAX_STRING] = { 0 };
+	bBuffs[0] = '\0';
+	bSongs[0] = '\0';
+	bBuffd[0] = '\0';	
+	bSongd[0] = '\0';
+	ZeroMemory(&dValues, sizeof(dValues));
+	AvailBuffSlots = GetCharMaxBuffSlots();
+	detrStatus = 0;
+	beneStatus = 0;
+	invisStatus = 0;
+	for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+		if (auto spell = GetSpellByID(GetPcProfile()->GetEffect(i).SpellID)) {
+			if (spell->ID > 0) {
+				sprintf_s(szTemp, "%d:", spell->ID);
+				strcat_s(bBuffs, szTemp);
+				AvailBuffSlots--;
+				if (NetExtended >= EX_GEMS_AND_BUFF_DURATIONS) {
+					int t = GetSpellBuffTimer(spell->ID);
+					// Send as Ticks (to help reduce EQBC spam). Negative is 'permanent', show as 9999.
+					sprintf_s(szTemp, "%d:", static_cast<int32_t>(t < 0 ? 9999 : ((t / 1000) + 5) / 6));
+					strcat_s(bBuffd, szTemp);
+				}
+				if (spell->SpellType == SpellType_Detrimental) {
+					EvalDetrimental(spell);
+				} else {
+					EvalBeneficial(spell);
+				}
 			}
 		}
 	}
-	dValues[COUNTERS] = dValues[CURSED] + dValues[DISEASED] + dValues[POISONED] + dValues[CORRUPTED];
-	for (int a = 0; a < DSIZE; a++) {
-		sprintf_s(tmp, "%d:", dValues[a]);
-		strcat_s(Buffer, tmp);
+	for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+		if (auto spell = GetSpellByID(GetPcProfile()->GetTempEffect(i).SpellID)) {
+			if (spell->ID > 0) {
+				sprintf_s(szTemp, "%d:", spell->ID);
+				strcat_s(bSongs, szTemp);
+				if (NetExtended >= EX_SONG_DURATIONS) {
+					int t = GetSpellBuffTimer(spell->ID);
+					// Send as Ticks (to help reduce EQBC spam). Negative is 'permanent', show as 9999.
+					sprintf_s(szTemp, "%d:", static_cast<int32_t>(t < 0 ? 9999 : ((t / 1000) + 5) / 6));
+					strcat_s(bSongd, szTemp);
+				}
+				if(spell->SpellType == SpellType_Detrimental) {
+					EvalDetrimental(spell);
+				} else {
+					EvalBeneficial(spell);
+				}
+			}
+		}
 	}
-	return Buffer;
+	if (detrStatus & BD_DISEASED) {
+		dValues[D_DISEASED] += GetMySpellCounters(SPA_DISEASE);
+		dValues[D_COUNTERS] += dValues[D_DISEASED];
+	}
+	if (detrStatus & BD_POISONED) {
+		dValues[D_POISONED] += GetMySpellCounters(SPA_POISON);
+		dValues[D_COUNTERS] += dValues[D_POISONED];
+	}
+	if (detrStatus & BD_CURSED) {
+		dValues[D_CURSED] += GetMySpellCounters(SPA_CURSE);
+		dValues[D_COUNTERS] += dValues[D_CURSED];
+	}
+	if (detrStatus & BD_CORRUPTED) {
+		dValues[D_CORRUPTED] += GetMySpellCounters(SPA_CORRUPTION);
+		dValues[D_COUNTERS] += dValues[D_CORRUPTED];
+	}
+}
+
+void ScanPetBuffs() {
+	char szTemp[MAX_STRING] = { 0 };
+	bPBuffs[0] = '\0';
+	bPBuffd[0] = '\0';	
+	auto Pet = GetSpawnByID(pLocalPlayer->PetID);
+	if (Pet && pPetInfoWnd)	{
+		for (int i = 0; i < PETS_MAX; i++) {
+			if (auto spell = GetSpellByID(pPetInfoWnd->GetBuff(i))) {
+				if (spell->ID > 0) {
+					sprintf_s(szTemp, "%d:", spell->ID);
+					strcat_s(bPBuffs, szTemp);
+					if (NetExtended >= EX_PET_DURATIONS) {
+						int t = pPetInfoWnd->GetBuffTimer(i);
+						// Send as Ticks (to help reduce EQBC spam). Negative is 'permanent', show as 9999.
+						sprintf_s(szTemp, "%d:", static_cast<int32_t>(t < 0 ? 9999 : ((t / 1000) + 5) / 6));
+						strcat_s(bPBuffd, szTemp);
+					}
+				}
+			}
+		}
+	}
+}
+
+bool SpellHasSPA(EQ_Spell* pSpell, eEQSPA eSPA, bool bIncrease) {
+	if (!pSpell) {
+		return false;
+	}
+	const SpellAffectData* spellAffect = nullptr;
+	for (int index = 0; index < pSpell->GetNumEffects(); ++index) {
+		if (const SpellAffectData* sad = pSpell->GetSpellAffectByIndex(index)) {
+			if (sad->Attrib == eSPA) {
+				spellAffect = sad;
+				break;
+			}
+		}
+	}
+	if (spellAffect == nullptr) {
+		return false;
+	}
+	auto base = spellAffect->Base;
+	switch (eSPA) {
+		case SPA_HP: 			// HP regen or drain/DoT. Below 0 is a drain/DoT or lich-like spell.
+		case SPA_MANA: 			// Mana regen or drain. Below 0 is a drain.
+		case SPA_MOVEMENT_RATE: // Movement Rate. Below 0 is a snare above is runspeed increase.
+		case SPA_FIZZLE_SKILL:
+		case SPA_ENDURANCE:  	// Endurance regen or drain. Below 0 is a drain.
+		case SPA_HEALMOD:
+		case SPA_FOCUS_MANACOST_MOD:
+		case SPA_FOCUS_DAMAGE_MOD:
+		case SPA_FOCUS_CAST_TIME_MOD:
+		case SPA_AC:
+			return (!bIncrease && base < 0) || (bIncrease && base > 0);
+		case SPA_HASTE: 		// Melee Speed. Below 100 is a slow, above is haste.
+			return (!bIncrease && base < 100) || (bIncrease && base > 100);
+		case SPA_DAMAGE_SHIELD: // Damage Shield
+			return (!bIncrease && base > 0) || (bIncrease && base < 0);
+		case SPA_IRONMAIDEN: 	// Reverse Damage Shield
+			return (!bIncrease && base > 0) || (bIncrease && base < 0);
+		default:				// Has the SPA
+			return true;
+	}
+}
+
+bool CheckSpellValues(EQ_Spell* pSpell, int spellSPA, bool bIncrease, int spellCategory, int spellSubcategory, int spellMask, bool hasMask = true) {
+	if (spellSPA >= 0 && !SpellHasSPA(pSpell, static_cast<eEQSPA>(spellSPA), bIncrease)) {
+		return false;
+	}
+	if (spellCategory && GetSpellCategory(pSpell) != spellCategory) {
+		return false;
+	}
+	if (spellSubcategory && GetSpellSubcategory(pSpell) != spellSubcategory) {
+		return false;
+	}
+	return (!spellMask || (hasMask == IsSpellUsableForClass(pSpell, spellMask)));
+}
+
+bool SpellHasAnyResistSPA(EQ_Spell* pSpell, bool bIncrease) {
+	if (!pSpell) {
+		return false;
+	}
+	const SpellAffectData* spellAffect = nullptr;
+	for (int index = 0; index < pSpell->GetNumEffects(); ++index) {
+		if (const SpellAffectData* sad = pSpell->GetSpellAffectByIndex(index)) {
+			if (sad->Attrib == SPA_RESIST_FIRE ||
+				sad->Attrib == SPA_RESIST_COLD ||
+				sad->Attrib == SPA_RESIST_POISON ||
+				sad->Attrib == SPA_RESIST_DISEASE ||
+				sad->Attrib == SPA_RESIST_MAGIC ||
+				sad->Attrib == SPA_RESIST_CORRUPTION ||
+				sad->Attrib == SPA_RESIST_ALL) {
+				spellAffect = sad;
+				auto base = spellAffect->Base;
+				if ((!bIncrease && base < 0) || (bIncrease && base > 0)) {
+					return true;
+				}
+			}
+		}
+	}
+	return false;
+}
+	
+bool CheckBotSpell(EQ_Spell* pSpell, int spellType) {
+	bool result = false;
+	switch (spellType) {
+		case ST_SLOWED:
+			result = CheckSpellValues(pSpell, SPA_HASTE, false, 0, 0, 0);
+			break;
+		case ST_ROOTED:
+			result = CheckSpellValues(pSpell, SPA_ROOT, true, 0, 0, 0);
+			break;
+		case ST_MESMERIZED:
+			result = CheckSpellValues(pSpell, SPA_ENTHRALL, true, 0, 0, 0);
+			break;
+		case ST_CRIPPLED:
+			result = CheckSpellValues(pSpell, -1, true, 0, SPELLCAT_DISEMPOWERING, 0);
+			break;
+		case ST_MALOED:
+			result = CheckSpellValues(pSpell, -1, true, 0, SPELLCAT_RESIST_DEBUFFS, SpellClassMask({ Shaman, Mage }));
+			break;
+		case ST_TASHED:
+			result = CheckSpellValues(pSpell, -1, true, 0, SPELLCAT_RESIST_DEBUFFS, SpellClassMask({ Enchanter }));
+			break;
+		case ST_SNARED:
+			result = CheckSpellValues(pSpell, SPA_MOVEMENT_RATE, false, 0, 0, 0);
+			break;
+		case ST_REVDSED:
+			result = CheckSpellValues(pSpell, SPA_IRONMAIDEN, true, 0, 0, 0);
+			break;
+		case ST_CHARMED:
+			result = CheckSpellValues(pSpell, SPA_CHARM, true, 0, 0, 0);
+			break;
+		case ST_DISEASED:
+			result = CheckSpellValues(pSpell, SPA_DISEASE, true, 0, 0, 0);
+			break;
+		case ST_POISONED:
+			result = CheckSpellValues(pSpell, SPA_POISON, true, 0, 0, 0);
+			break;
+		case ST_CURSED:
+			result = CheckSpellValues(pSpell, SPA_CURSE, true, 0, 0, 0);
+			break;
+		case ST_CORRUPTED:
+			result = CheckSpellValues(pSpell, SPA_CORRUPTION, true, 0, 0, 0);
+			break;
+		case ST_BLINDED:
+			result = CheckSpellValues(pSpell, SPA_BLINDNESS, true, 0, 0, 0);
+			break;
+		case ST_CASTINGLEVEL:
+			result = CheckSpellValues(pSpell, SPA_FIZZLE_SKILL, false, 0, 0, 0);
+			break;			
+		case ST_ENDUDRAIN:
+			result = CheckSpellValues(pSpell, SPA_ENDURANCE, false, 0, 0, 0);
+			break;
+		case ST_FEARED:
+			result = CheckSpellValues(pSpell, SPA_FEAR, true, 0, 0, 0);
+			break;
+		case ST_HEALING:
+			result = CheckSpellValues(pSpell, SPA_HEALMOD, false, 0, 0, 0);
+			break;
+		case ST_INVULNERABLE:
+			result = CheckSpellValues(pSpell, SPA_INVULNERABILITY, true, 0, 0, 0);
+			break;
+		case ST_LIFEDRAIN:
+			result = CheckSpellValues(pSpell, SPA_HP, false, 0, 0, 0);
+			break;
+		case ST_MANADRAIN:
+			result = CheckSpellValues(pSpell, SPA_MANA, false, 0, 0, 0);
+			break;
+		case ST_RESISTANCE:
+			result = SpellHasAnyResistSPA(pSpell, false);
+			break;
+		case ST_SILENCED:
+			result = CheckSpellValues(pSpell, SPA_SILENCE, true, 0, 0, 0);
+			break;
+		case ST_SPELLCOST:
+			result = CheckSpellValues(pSpell, SPA_FOCUS_MANACOST_MOD, false, 0, 0, 0);
+			break;
+		case ST_SPELLDAMAGE:
+			result = CheckSpellValues(pSpell, SPA_FOCUS_DAMAGE_MOD, false, 0, 0, 0);
+			break;
+		case ST_SPELLSLOWED:
+			result = CheckSpellValues(pSpell, SPA_FOCUS_CAST_TIME_MOD, false, 0, 0, 0);
+			break;
+		case ST_TRIGGER:
+			result = CheckSpellValues(pSpell, SPA_DOOM_EFFECT, true, 0, 0, 0);
+			break;
+		case ST_DSED:
+			result = CheckSpellValues(pSpell, SPA_DAMAGE_SHIELD, true, 0, 0, 0);
+			break;
+		case ST_AEGO:
+			result = CheckSpellValues(pSpell, SPA_AC, true, SPELLCAT_HP_BUFFS, SPELLCAT_AEGOLISM, SpellClassMask({ Cleric }));
+			break;
+		case ST_SKIN:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_HP_TYPE_ONE, SpellClassMask({ Druid }));
+			break;
+		case ST_FOCUS:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_SHIELDING, SpellClassMask({ Shaman }));
+			break;
+		case ST_REGEN:
+			result = CheckSpellValues(pSpell, SPA_HP, true, 0, 0, 0);
+			break;
+		case ST_SYMBOL:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_SYMBOL, SpellClassMask({ Cleric }));
+			break;
+		case ST_CLARITY:
+			result = CheckSpellValues(pSpell, SPA_MANA, true, 0, 0, SpellClassMask({ Enchanter }));
+			break;
+		case ST_PRED:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_STATISTIC_BUFFS, SPELLCAT_ATTACK, SpellClassMask({ Ranger }));
+			break;
+		case ST_STRENGTH:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_HP_TYPE_TWO, SpellClassMask({ Ranger }));
+			break;
+		case ST_BRELLS:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_HP_TYPE_TWO, SpellClassMask({ Paladin }));
+			break;
+		case ST_SV:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_HP_TYPE_TWO, SpellClassMask({ Beastlord }));
+			break;
+		case ST_SE:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_REGEN, SPELLCAT_HEALTH_MANA, SpellClassMask({ Beastlord }));
+			break;
+		case ST_HYBRIDHP:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_HP_TYPE_ONE, SpellClassMask({ Ranger }));
+			break;
+		case ST_GROWTH:
+			result = CheckSpellValues(pSpell, -1, true, SPELLCAT_HP_BUFFS, SPELLCAT_TEMPORARY, SpellClassMask({ Druid }));
+			break;
+		case ST_SHINING:
+			result = CheckSpellValues(pSpell, SPA_MELEE_GUARD, true, SPELLCAT_UTILITY_BENEFICIAL, SPELLCAT_MELEE_GUARD, SpellClassMask({ Cleric }));
+			break;
+		case ST_HASTED:
+			result = CheckSpellValues(pSpell, SPA_HASTE, true, 0, 0, 0);
+			break;
+		default:
+			break;
+	}
+	return result;
 }
 
 void BroadCast() {
 	char Buffer[MAX_STRING];
-	long nChange = false;
-	long nUpdate = false;
+	int nChange = 0;
 	ZeroMemory(wBuffer, sizeof(wBuffer));
 	ZeroMemory(wChange, sizeof(wChange));
 	ZeroMemory(wUpdate, sizeof(wUpdate));
-	sprintf_s(wBuffer[BUFFS], "B=%s|", MakeBUFFS(Buffer));
-	sprintf_s(wBuffer[CASTD], "C=%s|", MakeCASTD(Buffer));
-	sprintf_s(wBuffer[ENDUS], "E=%s|", MakeENDUS(Buffer));
-	sprintf_s(wBuffer[EXPER], "X=%s|", MakeEXPER(Buffer));
-	sprintf_s(wBuffer[LEADR], "N=%s|", MakeLEADR(Buffer));
-	sprintf_s(wBuffer[LEVEL], "L=%s|", MakeLEVEL(Buffer));
-	sprintf_s(wBuffer[LIFES], "H=%s|", MakeLIFES(Buffer));
-	sprintf_s(wBuffer[MANAS], "M=%s|", MakeMANAS(Buffer));
-	sprintf_s(wBuffer[PBUFF], "W=%s|", MakePBUFF(Buffer));
-	sprintf_s(wBuffer[PETIL], "P=%s|", MakePETIL(Buffer));
-	//  sprintf_s(wBuffer[SPGEM],"G=%s|",MakeSPGEM(Buffer));
-	sprintf_s(wBuffer[SONGS], "S=%s|", MakeSONGS(Buffer));
-	sprintf_s(wBuffer[STATE], "Y=%s|", MakeSTATE(Buffer));
-	sprintf_s(wBuffer[TARGT], "T=%s|", MakeTARGT(Buffer));
-	sprintf_s(wBuffer[ZONES], "Z=%s|", MakeZONES(Buffer));
-	//  sprintf_s(wBuffer[DURAS],"D=%s|",MakeDURAS(Buffer));
-	sprintf_s(wBuffer[AAPTS], "A=%s|", MakeAAPTS(Buffer));
-	sprintf_s(wBuffer[OOCST], "O=%s|", MakeOOCST(Buffer));
-	sprintf_s(wBuffer[NOTE], "U=%s|", MakeNOTE(Buffer));
-	sprintf_s(wBuffer[DETR], "R=%s|", MakeDETR(Buffer));
-	sprintf_s(wBuffer[LOCAT], "@=%s|", MakeLOCAT(Buffer));
-	sprintf_s(wBuffer[HEADN], "$=%s|", MakeHEADN(Buffer));
+	
+	ScanBuffs();
+	ScanPetBuffs();
+	
+	sprintf_s(wBuffer[E_BUFFS],   "B=%s|", MakeBUFFS(Buffer));	// Buff
+	sprintf_s(wBuffer[E_CASTD],   "C=%s|", MakeCASTD(Buffer));	// CastID
+	sprintf_s(wBuffer[E_ENDUS],   "E=%s|", MakeENDUS(Buffer));	// EnduranceCurrent, EnduranceMax
+	sprintf_s(wBuffer[E_EXPER],   "X=%s|", MakeEXPER(Buffer));	// Exp, AAExp, (GroupLeaderExp)
+	sprintf_s(wBuffer[E_LEADR],   "N=%s|", MakeLEADR(Buffer));	// Leader
+	sprintf_s(wBuffer[E_LEVEL],   "L=%s|", MakeLEVEL(Buffer));	// Level, ClassID
+	sprintf_s(wBuffer[E_HPS],     "H=%s|", MakeHPS(Buffer));	// HPCurrent, HPMax
+	sprintf_s(wBuffer[E_MANAS],   "M=%s|", MakeMANAS(Buffer));	// ManaCurrent, ManaMax		
+	sprintf_s(wBuffer[E_PBUFF],   "W=%s|", MakePBUFF(Buffer));	// Pets
+	sprintf_s(wBuffer[E_PETIL],   "P=%s|", MakePETIL(Buffer));	// PetID, PetHPPct
+	sprintf_s(wBuffer[E_SONGS],   "S=%s|", MakeSONGS(Buffer));	// Song
+	sprintf_s(wBuffer[E_STATE],   "Y=%s|", MakeSTATE(Buffer));	// State
+	sprintf_s(wBuffer[E_TARGT],   "T=%s|", MakeTARGT(Buffer));	// TargetID, TargetHPPct
+	sprintf_s(wBuffer[E_ZONES],   "Z=%s|", MakeZONES(Buffer));	// ZoneID, InstanceID, SpawnID
+	sprintf_s(wBuffer[E_AAPTS],   "A=%s|", MakeAAPTS(Buffer));	// AAPoints, AAPointsSpent, AAPointsAssigned
+	sprintf_s(wBuffer[E_OOCST],   "O=%s|", MakeOOCST(Buffer));	// CombatState
+	sprintf_s(wBuffer[E_NOTE],    "U=%s|", MakeNOTE(Buffer));	// Note
+	sprintf_s(wBuffer[E_DETR],    "R=%s|", MakeDETR(Buffer));	// Detrimental
+	sprintf_s(wBuffer[E_LOCAT],   "@=%s|", MakeLOCAT(Buffer));	// Location (and X,Y,Z derived)
+	sprintf_s(wBuffer[E_HEADN],   "$=%s|", MakeHEADN(Buffer));	// Heading
+	sprintf_s(wBuffer[E_FREEB],   "F=%s|", MakeFREEB(Buffer));	// FreeBuff
+	sprintf_s(wBuffer[E_EXTEND],  "<=%s|", MakeEXTEND(Buffer));	// Extended
+	sprintf_s(wBuffer[E_MACRO],   "&=%s|", MakeMACRO(Buffer));	// MacroState, MacroName
+	sprintf_s(wBuffer[E_FREEI],   "I=%s|", MakeFREEI(Buffer));	// FreeInventory
+	sprintf_s(wBuffer[E_VERSN],   "V=%s|", MakeVERSN(Buffer));	// Version
+	sprintf_s(wBuffer[E_CAMPS],   "K=%s|", MakeCAMPS(Buffer));	// MakeCampStatus, MakeCampX, MakeCampY, MakeCampRadius, MakeCampDistance
+	sprintf_s(wBuffer[E_LUAINFO], "+=%s|", MakeLUA(Buffer));	// LuaInfo
+	sprintf_s(wBuffer[E_EQBC],    "-=%s|", MakeEQBC(Buffer));	// EQBC_Packets, EQBC_HeartBeat
+	sprintf_s(wBuffer[E_QUERY],   "Q=%s|", MakeQUERY(Buffer));	// Query
+	sprintf_s(wBuffer[E_BSTAT],   "J=%s|", MakeBSTAT(Buffer));	// DetrState, BeneState
+    sprintf_s(wBuffer[E_SPGEM],   "G=%s|", MakeSPGEM(Buffer));	// Gem
+    sprintf_s(wBuffer[E_BUFFD],   "D=%s|", MakeBUFFD(Buffer));	// BDuration
+	sprintf_s(wBuffer[E_SONGD],   ":=%s|", MakeSONGD(Buffer));	// SDuration
+	sprintf_s(wBuffer[E_PETD],    ";=%s|", MakePETD(Buffer));	// PDuration
 
-	//  WriteChatf("D=%s|", Buffer);
-	for (int i = 0; i < ESIZE; i++)
-		if ((clock() > sTimers[i] && clock() > sTimers[i] + UPDATES) || 0 != strcmp(wBuffer[i], sBuffer[i])) {
+	for (int i = 0; i < ESIZE; i++) {
+		if ((clock() > sTimers[i] + UPDATES) || strcmp(wBuffer[i],sBuffer[i]) != 0) {
 			wChange[i] = true;
 			nChange++;
-		}
-		else if (clock() < sTimers[i] && clock() + UPDATES > sTimers[i]) {
+		} else if (clock() < sTimers[i] && clock() + UPDATES > sTimers[i]) {
 			wUpdate[i] = true;
-			nUpdate++;
 		}
+	}
 	if (nChange) {
 		strcpy_s(Buffer, "[NB]|");
-		for (int i = 0; i < ESIZE; i++)
-			if (wChange[i] || wUpdate[i] && (strlen(Buffer) + strlen(wBuffer[i])) < MAX_STRING - 5) {
-				strcat_s(Buffer, wBuffer[i]);
-				sTimers[i] = (long)clock() + REFRESH;
+		for (int i = 0; i < ESIZE; i++) {
+			if (wChange[i] || wUpdate[i]) {
+				if (strlen(Buffer) + strlen(wBuffer[i]) < MAX_STRING - 5) {
+					strcat_s(Buffer, wBuffer[i]);
+					sTimers[i] = (int)clock() + REFRESH;
+				}
+//				else WriteChatf("Skipping i=%d buffer=%d wbuffer=%d", i, strlen(Buffer), strlen(wBuffer[i]));
 			}
+		}
 		strcat_s(Buffer, "[NB]");
-		// WriteChatf("Broadcast %s", Buffer);
+		
+//		WriteChatf("Broadcast %s", Buffer);
 
 		EQBCBroadCast(Buffer);
 		memcpy(sBuffer, wBuffer, sizeof(wBuffer));
-		if (CurBot = BotLoad(GetCharInfo()->Name).get()) {
+		if (CurBot = BotLoad(pLocalPC->Name).get()) {
 			Packet.Feed(Buffer);
 			CurBot->Updated = clock();
 			CurBot = 0;
@@ -934,105 +1640,166 @@ void BroadCast() {
 class MQ2NetBotsType *pNetBotsType = 0;
 class MQ2NetBotsType : public MQ2Type {
 
-private:
-	char Temps[MAX_STRING];
-	char Works[MAX_STRING];
-	long Cpt;
-
 public:
 	enum Information {
 		Enable = 1,
-		Listen = 2,
-		Output = 3,
-		Counts = 5,
-		Client = 6,
-		Name = 7,
-		Zone = 8,
-		Instance = 9,
-		ID = 10,
-		Class = 11,
-		Level = 12,
-		PctExp = 13,
-		PctAAExp = 14,
-#if HAS_LEADERSHIP_EXPERIENCE
-		PctGroupLeaderExp = 15,
-#endif
-		CurrentHPs = 16,
-		MaxHPs = 17,
-		PctHPs = 18,
-		CurrentEndurance = 19,
-		MaxEndurance = 20,
-		PctEndurance = 21,
-		CurrentMana = 22,
-		MaxMana = 23,
-		PctMana = 24,
-		PetID = 25,
-		PetHP = 26,
-		TargetID = 27,
-		TargetHP = 28,
-		Casting = 29,
-		State = 30,
-		Attacking = 31,
-		AFK = 32,
-		Binding = 33,
-		Ducking = 34,
-		Invis = 35,
-		Feigning = 36,
-		Grouped = 37,
-		Levitating = 38,
-		LFG = 39,
-		Mounted = 40,
-		Moving = 41,
-		Raid = 42,
-		Sitting = 43,
-		Standing = 44,
-		Stunned = 45,
-		//    Gem=46,
-		Buff = 47,
-		ShortBuff = 48,
-		PetBuff = 49,
-		FreeBuffSlots = 50,
-		InZone = 51,
-		InGroup = 52,
-		Leader = 53,
-		Updated = 54,
-		//    Duration=55,
-		TotalAA = 56,
-		UsedAA = 57,
-		UnusedAA = 58,
-		CombatState = 59,
-		Stacks = 60,
-		Note = 61,
-		Detrimentals = 62,
-		Counters = 63,
-		Cursed = 64,
-		Diseased = 65,
-		Poisoned = 66,
-		Corrupted = 67,
-		EnduDrain = 68,
-		LifeDrain = 69,
-		ManaDrain = 70,
-		Blinded = 71,
-		CastingLevel = 72,
-		Charmed = 73,
-		Feared = 74,
-		Healing = 75,
-		Invulnerable = 76,
-		Mesmerized = 77,
-		Rooted = 78,
-		Silenced = 79,
-		Slowed = 80,
-		Snared = 81,
-		SpellCost = 82,
-		SpellSlowed = 83,
-		SpellDamage = 84,
-		Trigger = 85,
-		Resistance = 86,
-		Detrimental = 87,
-		NoCure = 88,
-		Location = 89,
-		Heading = 90,
-		StacksPet = 91,
+		Listen,
+		Output,
+		Counts,
+		Client,
+		Name,
+		Zone,
+		Instance,
+		ID,
+		Class,
+		Level,
+		PctExp,
+		PctAAExp,
+		PctGroupLeaderExp,
+		CurrentHPs,
+		MaxHPs,
+		PctHPs,
+		CurrentMana,
+		MaxMana,
+		PctMana,
+		CurrentEndurance,
+		MaxEndurance,
+		PctEndurance,
+		PetID,
+		PetHP,
+		PetPctHPs,
+		TargetID,
+		TargetHP,
+		TargetPctHPs,
+		Casting,
+		State,
+		Attacking,
+		AFK,
+		Binding,
+		Ducking,
+		Feigning,
+		Grouped,
+		Invis,
+		Levitating,
+		LFG,
+		Mounted,
+		Moving,
+		Raid,
+		Sitting,
+		Standing,
+		Stunned,
+		Dead,
+		Hover,
+		InvisToUndead,
+		AutoFire,
+		HaveAggro,
+		WantAggro,
+		NavigationActive,
+		NavigationPaused,
+		BotActive,
+		PetAffinity,
+		Extended,
+		FreeBuffSlots,
+		InZone,
+		InGroup,
+		Leader,
+		GroupLeader,
+		Note,
+		Location,
+		X,
+		Y,
+		Z,
+		Distance,
+		Heading,
+		Updated,
+		Gem,
+		Buff,
+		Duration,
+		BuffDuration,
+		ShortBuff,
+		ShortDuration,
+		PetBuff,
+		PetDuration,
+		TotalAA,
+		AAPointsTotal,
+		UsedAA,
+		AAPointsSpent,
+		UnusedAA,
+		AAPoints,
+		AAPointsAssigned,
+		CombatState,
+		Stacks,
+		StacksPet,
+		WillLand,
+		WillLandPet,
+		TooPowerful,
+		TooPowerfulPet,
+		Detrimentals,
+		Counters,
+		TotalCounters,
+		CountersCurse,
+		CountersDisease,
+		CountersPoison,
+		CountersCorruption,
+		NoCure,
+		LifeDrain,
+		ManaDrain,
+		EnduDrain,
+		Cursed,
+		Diseased,
+		Poisoned,
+		Corrupted,
+		Blinded,
+		CastingLevel,
+		Charmed,
+		Feared,
+		Healing,
+		Invulnerable,
+		Mesmerized,
+		Rooted,
+		Silenced,
+		Slowed,
+		Snared,
+		SpellCost,
+		SpellSlowed,
+		SpellDamage,
+		Trigger,
+		Resistance,
+		Detrimental,
+		RevDSed,
+		MacroState,
+		MacroName,
+		FreeInventory,
+		Version,
+		MakeCampStatus,
+		MakeCampX,
+		MakeCampY,
+		MakeCampRadius,
+		MakeCampDistance,
+		Lua,
+		Packets,
+		HeartBeat,
+		Query,
+		Crippled,
+		Maloed,
+		Tashed,
+		Hasted,
+		DSed,
+		Aego,
+		Skin,
+		Focus,
+		Regen,
+		Symbol,
+		Clarity,
+		Pred,
+		Strength,
+		Brells,
+		SV,
+		SE,
+		HybridHP,
+		Growth,
+		Shining,
+		Spell
 	};
 
 	MQ2NetBotsType() :MQ2Type("NetBots") {
@@ -1049,31 +1816,31 @@ public:
 		TypeMember(Level);
 		TypeMember(PctExp);
 		TypeMember(PctAAExp);
-#if HAS_LEADERSHIP_EXPERIENCE
 		TypeMember(PctGroupLeaderExp);
-#endif
 		TypeMember(CurrentHPs);
 		TypeMember(MaxHPs);
 		TypeMember(PctHPs);
-		TypeMember(CurrentEndurance);
-		TypeMember(MaxEndurance);
-		TypeMember(PctEndurance);
 		TypeMember(CurrentMana);
 		TypeMember(MaxMana);
 		TypeMember(PctMana);
+		TypeMember(CurrentEndurance);
+		TypeMember(MaxEndurance);
+		TypeMember(PctEndurance);
 		TypeMember(PetID);
 		TypeMember(PetHP);
+		TypeMember(PetPctHPs);		// Same as PetHP
 		TypeMember(TargetID);
 		TypeMember(TargetHP);
+		TypeMember(TargetPctHPs);	// Same as TargetHP
 		TypeMember(Casting);
 		TypeMember(State);
 		TypeMember(Attacking);
 		TypeMember(AFK);
 		TypeMember(Binding);
 		TypeMember(Ducking);
-		TypeMember(Invis);
 		TypeMember(Feigning);
 		TypeMember(Grouped);
+		TypeMember(Invis);
 		TypeMember(Levitating);
 		TypeMember(LFG);
 		TypeMember(Mounted);
@@ -1082,31 +1849,67 @@ public:
 		TypeMember(Sitting);
 		TypeMember(Standing);
 		TypeMember(Stunned);
-		//    TypeMember(Gem);
-		TypeMember(Buff);
-		TypeMember(ShortBuff);
-		TypeMember(PetBuff);
+		TypeMember(Dead);
+		TypeMember(Hover);
+		TypeMember(InvisToUndead);
+		TypeMember(AutoFire);
+		TypeMember(HaveAggro);
+		TypeMember(WantAggro);
+		TypeMember(NavigationActive);
+		TypeMember(NavigationPaused);
+		TypeMember(BotActive);
+		TypeMember(PetAffinity);
+		TypeMember(Extended);
 		TypeMember(FreeBuffSlots);
 		TypeMember(InZone);
 		TypeMember(InGroup);
 		TypeMember(Leader);
+		TypeMember(GroupLeader);    // Same as Leader
+		TypeMember(Note);
+		TypeMember(Location);
+		TypeMember(X);
+		TypeMember(Y);
+		TypeMember(Z);
+		TypeMember(Distance);
+		TypeMember(Heading);
 		TypeMember(Updated);
-		//    TypeMember(Duration);
+		TypeMember(Gem);
+		TypeMember(Buff);
+		TypeMember(Duration);
+		TypeMember(BuffDuration);   // Same as Duration
+		TypeMember(ShortBuff);
+		TypeMember(ShortDuration);
+		TypeMember(PetBuff);
+		TypeMember(PetDuration);
 		TypeMember(TotalAA);
+		TypeMember(AAPointsTotal);	// Same as TotalAA
 		TypeMember(UsedAA);
+		TypeMember(AAPointsSpent);	// Same as UsedAA
 		TypeMember(UnusedAA);
+		TypeMember(AAPoints);		// Same as UnusedAA
+		TypeMember(AAPointsAssigned);
 		TypeMember(CombatState);
 		TypeMember(Stacks);
-		TypeMember(Note);
+		TypeMember(StacksPet);
+		TypeMember(WillLand);
+		TypeMember(WillLandPet);
+		TypeMember(TooPowerful);
+		TypeMember(TooPowerfulPet);
 		TypeMember(Detrimentals);
 		TypeMember(Counters);
+		TypeMember(TotalCounters);
+		TypeMember(CountersCurse);
+		TypeMember(CountersDisease);
+		TypeMember(CountersPoison);
+		TypeMember(CountersCorruption);
+		TypeMember(NoCure);
+		TypeMember(LifeDrain);
+		TypeMember(ManaDrain);
+		TypeMember(EnduDrain);
 		TypeMember(Cursed);
 		TypeMember(Diseased);
 		TypeMember(Poisoned);
 		TypeMember(Corrupted);
-		TypeMember(EnduDrain);
-		TypeMember(LifeDrain);
-		TypeMember(ManaDrain);
 		TypeMember(Blinded);
 		TypeMember(CastingLevel);
 		TypeMember(Charmed);
@@ -1124,588 +1927,1117 @@ public:
 		TypeMember(Trigger);
 		TypeMember(Resistance);
 		TypeMember(Detrimental);
-		TypeMember(NoCure);
-		TypeMember(StacksPet);
-		TypeMember(Location);
-		TypeMember(Heading);
+		TypeMember(RevDSed);
+		TypeMember(MacroState);
+		TypeMember(MacroName);
+		TypeMember(FreeInventory);
+		TypeMember(Version);
+		TypeMember(MakeCampStatus);
+		TypeMember(MakeCampX);
+		TypeMember(MakeCampY);
+		TypeMember(MakeCampRadius);
+		TypeMember(MakeCampDistance);
+		TypeMember(Lua);
+		TypeMember(Packets);
+		TypeMember(HeartBeat);
+		TypeMember(Query);
+		TypeMember(Crippled);
+		TypeMember(Maloed);
+		TypeMember(Tashed);
+		TypeMember(Hasted);
+		TypeMember(DSed);
+		TypeMember(Aego);
+		TypeMember(Skin);
+		TypeMember(Focus);
+		TypeMember(Regen);
+		TypeMember(Symbol);
+		TypeMember(Clarity);
+		TypeMember(Pred);
+		TypeMember(Strength);
+		TypeMember(Brells);
+		TypeMember(SV);
+		TypeMember(SE);
+		TypeMember(HybridHP);
+		TypeMember(Growth);
+		TypeMember(Shining);
+		TypeMember(Spell);
 	}
 
 	virtual bool GetMember(MQVarPtr VarPtr, const char* Member, char* Index, MQTypeVar& Dest) override {
 		if (auto pMember = MQ2NetBotsType::FindMember(Member)) {
 			switch ((Information)pMember->ID) {
-			case Enable:
-				Dest.Type = mq::datatypes::pBoolType;
-				Dest.DWord = NetStat;
-				return true;
-			case Listen:
-				Dest.Type = mq::datatypes::pBoolType;
-				Dest.DWord = NetGrab;
-				return true;
-			case Output:
-				Dest.Type = mq::datatypes::pBoolType;
-				Dest.DWord = NetSend;
-				return true;
-			case Counts:
-				Cpt = 0;
-				if (NetStat && NetGrab)
-					for (auto& [_, botInfo] : NetMap) {
-						if (botInfo->SpawnID == 0) 
-							continue;
-						Cpt++;
-					}
-				Dest.Type = mq::datatypes::pIntType;
-				Dest.Int = Cpt;
-				return true;
-			case Client:
-				Cpt = 0; Temps[0] = 0;
-				if (NetStat && NetGrab)
-					for (auto& [_, botInfo] : NetMap) {
-						if (botInfo->SpawnID == 0) 
-							continue;
-						if (Cpt++) strcat_s(Temps, " ");
-						strcat_s(Temps, botInfo->Name);
-					}
-				if (IsNumber(Index)) {
-					int n = atoi(Index);
-					if (n<0 || n>Cpt) break;
-					strcpy_s(Temps, GetArg(Works, Temps, n));
-				}
-
-				Dest.Type = mq::datatypes::pStringType;
-				Dest.Ptr = Temps;
-				return true;
-			}
-			if (auto botRec = VarPtr.Get<BotInfo>()) {
-				switch ((Information)pMember->ID) {
-				case Name:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					strcpy_s(Temps, botRec->Name);
-					return true;
-				case Zone:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->ZoneID;
-					return true;
-				case Instance:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->InstID;
-					return true;
-				case ID:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->SpawnID;
-					return true;
-				case Class:
-					Dest.Type = mq::datatypes::pClassType;
-					Dest.DWord = botRec->ClassID;
-					return true;
-				case Level:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->Level;
-					return true;
-				case PctExp:
-					Dest.Type = mq::datatypes::pFloatType;
-					Dest.Float = (float)(botRec->XP / 3.30f);
-					return true;
-				case PctAAExp:
-					Dest.Type = mq::datatypes::pFloatType;
-					Dest.Float = (float)(botRec->aaXP / 3.30f);
-					return true;
-#if HAS_LEADERSHIP_EXPERIENCE
-				case PctGroupLeaderExp:
-					Dest.Type = mq::datatypes::pFloatType;
-					Dest.Float = (float)(botRec->glXP / 10.0f);
-					return true;
-#endif
-				case CurrentHPs:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->LifeCur;
-					return true;
-				case MaxHPs:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->LifeMax;
-					return true;
-				case PctHPs:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = (botRec->LifeMax < 1 || botRec->LifeCur < 1) ? 0 : botRec->LifeCur * 100 / botRec->LifeMax;
-					return true;
-				case CurrentEndurance:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->EnduCur;
-					return true;
-				case MaxEndurance:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->EnduMax;
-					return true;
-				case PctEndurance:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = (botRec->EnduMax < 1 || botRec->EnduCur < 1) ? 0 : botRec->EnduCur * 100 / botRec->EnduMax;
-					return true;
-				case CurrentMana:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->ManaCur;
-					return true;
-				case MaxMana:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->ManaMax;
-					return true;
-				case PctMana:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = (botRec->ManaMax < 1 || botRec->ManaCur < 1) ? 0 : botRec->ManaCur * 100 / botRec->ManaMax;
-					return true;
-				case PetID:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->PetID;
-					return true;
-				case PetHP:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->PetHP;
-					return true;
-				case TargetID:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->TargetID;
-					return true;
-				case TargetHP:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->TargetHP;
-					return true;
-				case Casting:
-					if (botRec->CastID) {
-						Dest.Type = mq::datatypes::pSpellType;
-						Dest.Ptr = GetSpellByID(botRec->CastID);
-						return true;
-					}
-					break;
-				case State:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					if (botRec->State & STATE_STUN)       strcpy_s(Temps, "STUN");
-					else if (botRec->State & STATE_STAND) strcpy_s(Temps, "STAND");
-					else if (botRec->State & STATE_SIT)   strcpy_s(Temps, "SIT");
-					else if (botRec->State & STATE_DUCK)  strcpy_s(Temps, "DUCK");
-					else if (botRec->State & STATE_BIND)  strcpy_s(Temps, "BIND");
-					else if (botRec->State & STATE_FEIGN) strcpy_s(Temps, "FEIGN");
-					else if (botRec->State & STATE_DEAD)  strcpy_s(Temps, "DEAD");
-					else strcpy_s(Temps, "UNKNOWN");
-					return true;
-				case Attacking:
+				case Enable:
+					Dest.DWord = NetStat;
 					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_ATTACK;
 					return true;
-				case AFK:
+				case Listen:
+					Dest.DWord = NetGrab;
 					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_AFK;
 					return true;
-				case Binding:
+				case Output:
+					Dest.DWord = NetSend;
 					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_BIND;
 					return true;
-				case Ducking:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_DUCK;
-					return true;
-				case Feigning:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_FEIGN;
-					return true;
-				case Grouped:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_GROUP;
-					return true;
-				case Invis:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_INVIS;
-					return true;
-				case Levitating:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_LEV;
-					return true;
-				case LFG:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_LFG;
-					return true;
-				case Mounted:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_MOUNT;
-					return true;
-				case Moving:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_MOVING;
-					return true;
-				case Raid:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_RAID;
-					return true;
-				case Sitting:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_SIT;
-					return true;
-				case Standing:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_STAND;
-					return true;
-				case Stunned:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = botRec->State & STATE_STUN;
-					return true;
-				case FreeBuffSlots:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->FreeBuff;
-					return true;
-				case InZone:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = (inZoned(botRec->ZoneID, botRec->InstID));
-					return true;
-				case InGroup:
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = (inZoned(botRec->ZoneID, botRec->InstID) && inGroup(botRec->SpawnID));
-					return true;
-				case Leader:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					strcpy_s(Temps, botRec->Leader);
-					return true;
-				case Note:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					strcpy_s(Temps, botRec->Note);
-					return true;
-				case Location:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					strcpy_s(Temps, botRec->Location);
-					return true;
-				case Heading:
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					strcpy_s(Temps, botRec->Heading);
-					return true;
-				case Updated:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = clock() - botRec->Updated;
-					return true;
-					/*
-							case Gem:
-							  if(!Index[0]) {
-								Temps[0]=0;
-								for (Cpt=0; Cpt<GEMS_MAX; Cpt++) {
-								  sprintf_s(Works,"%d ",botRec->Gem[Cpt]);
-								  strcat_s(Temps,Works);
-								}
-								Dest.Ptr=Temps;
-								Dest.Type=pStringType;
-								return true;
-							  }
-							  Cpt=atoi(Index);
-							  if(Cpt<GEMS_MAX && Cpt>-1)
-								if(Dest.Ptr=GetSpellByID(botRec->Gem[Cpt])) {
-								  Dest.Type=pSpellType;
-								  return true;
-								}
-								break;
-					*/
-				case Buff:
-					if (!Index[0]) {
-						Temps[0] = '\0';
-						for (Cpt = 0; Cpt < BUFF_MAX && botRec->Buff[Cpt]; Cpt++) {
-							sprintf_s(Works, "%d ", botRec->Buff[Cpt]);
-							strcat_s(Temps, Works);
-						}
-						Dest.Ptr = Temps;
-						Dest.Type = mq::datatypes::pStringType;
-						return true;
-					}
-					Cpt = atoi(Index);
-					if (Cpt<BUFF_MAX && Cpt>-1)
-						if (Dest.Ptr = GetSpellByID(botRec->Buff[Cpt])) {
-							Dest.Type = mq::datatypes::pSpellType;
-							return true;
-						}
-					break;
-					/*
-							case Duration:
-							  if(!Index[0]) {
-								Temps[0]=0;
-								for (Cpt=0; Cpt<BUFF_MAX && botRec->Duration[Cpt]; Cpt++) {
-								  sprintf_s(Works,"%d ",botRec->Duration[Cpt]);
-								  strcat_s(Temps,Works);
-								}
-								Dest.Ptr=Temps;
-								Dest.Type=pStringType;
-								return true;
-							  }
-							  Cpt=atoi(Index);
-							  if(Cpt<BUFF_MAX && Cpt>-1)
-						  //   WriteChatf("Duration: %d", botRec->Duration[Cpt]);
-								if(Dest.Int=botRec->Duration[Cpt]) {
-								  Dest.Type=pIntType;
-								  return true;
-								 }
-							  break;
-					*/
-				case ShortBuff:
-					if (!Index[0]) {
-						Temps[0] = 0;
-						for (Cpt = 0; Cpt < SONG_MAX && botRec->Song[Cpt]; Cpt++) {
-							sprintf_s(Works, "%d ", botRec->Song[Cpt]);
-							strcat_s(Temps, Works);
-						}
-						Dest.Ptr = Temps;
-						Dest.Type = mq::datatypes::pStringType;
-						return true;
-					}
-					Cpt = atoi(Index);
-					if (Cpt<SONG_MAX && Cpt>-1)
-						if (Dest.Ptr = GetSpellByID(botRec->Song[Cpt])) {
-							Dest.Type = mq::datatypes::pSpellType;
-							return true;
-						}
-					break;
-				case PetBuff:
-					if (!Index[0]) {
-						Temps[0] = '\0';
-						for (Cpt = 0; Cpt < PETS_MAX && botRec->Pets[Cpt]; Cpt++) {
-							sprintf_s(Works, "%d ", botRec->Pets[Cpt]);
-							strcat_s(Temps, Works);
-						}
-						Dest.Ptr = Temps;
-						Dest.Type = mq::datatypes::pStringType;
-						return true;
-					}
-					Cpt = atoi(Index);
-					if (Cpt<PETS_MAX && Cpt>-1)
-						if (Dest.Ptr = GetSpellByID(botRec->Pets[Cpt])) {
-							Dest.Type = mq::datatypes::pSpellType;
-							return true;
-						}
-					break;
-				case TotalAA:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->TotalAA;
-					return true;
-				case UsedAA:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->UsedAA;
-					return true;
-				case UnusedAA:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->UnusedAA;
-					return true;
-				case CombatState:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.DWord = botRec->CombatState;
-					return true;
-				case Stacks:
-				{
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = false;
-					if (!ISINDEX())
-						return true;
-					PSPELL tmpSpell = NULL;
-					if (ISNUMBER())
-						tmpSpell = GetSpellByID(GETNUMBER());
-					else
-						tmpSpell = GetSpellByName(GETFIRST());
-					if (!tmpSpell)
-						return true;
-					Dest.DWord = true;
-					// Check Buffs
-					for (Cpt = 0; Cpt < BUFF_MAX; Cpt++) {
-						if (botRec->Buff[Cpt]) {
-							if (auto buffSpell = GetSpellByID(botRec->Buff[Cpt])) {
-								if (!NBBuffStackTest(tmpSpell, buffSpell, TRUE, TRUE) || (buffSpell == tmpSpell)) {
-									Dest.DWord = false;
-									return true;
-								}
+				case Counts: {
+					int iCount = 0;
+					if (NetStat && NetGrab) {
+						for (auto& [_, botInfo] : NetMap) {
+							if (botInfo->SpawnID != 0) {
+								iCount++;
 							}
 						}
 					}
-					// Check Songs
-					for (Cpt = 0; Cpt < SONG_MAX; Cpt++) {
-						if (botRec->Song[Cpt]) {
-							if (auto buffSpell = GetSpellByID(botRec->Song[Cpt])) {
-								if (!IsBardSong(buffSpell) && !((IsSPAEffect(tmpSpell, SPA_CHANGE_FORM) && !tmpSpell->DurationWindow))) {
-									if (!NBBuffStackTest(tmpSpell, buffSpell, TRUE, TRUE) || (buffSpell == tmpSpell)) {
-										Dest.DWord = false;
+					Dest.Int = iCount;
+					Dest.Type = mq::datatypes::pIntType;
+					return true;
+				}
+				case Client: {
+					int iCount = 0;
+					DataTypeTemp[0] = '\0';
+					int n = ((Index[0] && IsNumber(Index)) ? GetIntFromString(Index, 0) : 0);
+					if (NetStat && NetGrab) {
+						for (auto& [_, botInfo] : NetMap) {
+							if (botInfo->SpawnID != 0) {
+								iCount++;
+								if (n > 0) {
+									if (n == iCount) {
+										strcpy_s(DataTypeTemp, botInfo->Name);
+										Dest.Ptr = &DataTypeTemp[0];
+										Dest.Type = mq::datatypes::pStringType;
 										return true;
+									}
+								} else {
+									if (iCount > 1) {
+										strcat_s(DataTypeTemp, " ");
+									}
+									strcat_s(DataTypeTemp, botInfo->Name);
+								}
+							}
+						}
+					}					
+					if(!Index[0]) {
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					}
+					break;
+				}
+				default:
+					break;
+			}
+			if (auto botRec = VarPtr.Get<BotInfo>()) {
+				switch ((Information)pMember->ID) {
+					case Name:
+						strcpy_s(DataTypeTemp, botRec->Name);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Zone:
+						Dest.DWord = botRec->ZoneID;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case Instance:
+						Dest.DWord = botRec->InstanceID;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case ID:
+						Dest.DWord = botRec->SpawnID;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case Class:
+						Dest.DWord = botRec->ClassID;
+						Dest.Type = mq::datatypes::pClassType;
+						return true;
+					case Level:
+						Dest.DWord = botRec->Level;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PctExp:
+						Dest.Float = static_cast<float>(botRec->Exp) / EXP_TO_PCT_RATIO;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case PctAAExp:
+						Dest.Float = static_cast<float>(botRec->AAExp) / EXP_TO_PCT_RATIO;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case PctGroupLeaderExp:
+#if HAS_LEADERSHIP_EXPERIENCE
+						Dest.Float = static_cast<float>(botRec->GroupLeaderExp) / 10.0f;
+#else
+						Dest.Float = 0.0f;
+#endif
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case CurrentHPs:
+						Dest.Int = botRec->HPCurrent;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case MaxHPs:
+						Dest.Int = botRec->HPMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PctHPs:
+						Dest.Int = (botRec->HPMax == 0) ? 0 : botRec->HPCurrent * 100 / botRec->HPMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case CurrentMana:
+						Dest.Int = botRec->ManaCurrent;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case MaxMana:
+						Dest.Int = botRec->ManaMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PctMana:
+						Dest.Int = (botRec->ManaMax == 0) ? 0 : botRec->ManaCurrent * 100 / botRec->ManaMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case CurrentEndurance:
+						Dest.Int = botRec->EnduranceCurrent;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case MaxEndurance:
+						Dest.Int = botRec->EnduranceMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PctEndurance:
+						Dest.Int = (botRec->EnduranceMax == 0) ? 0 : botRec->EnduranceCurrent * 100 / botRec->EnduranceMax;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PetID:
+						Dest.DWord = botRec->PetID;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case PetHP:
+					case PetPctHPs:
+						Dest.Int = botRec->PetHPPct;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case TargetID:
+						Dest.DWord = botRec->TargetID;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case TargetHP:
+					case TargetPctHPs:
+						Dest.Int = botRec->TargetHPPct;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case Casting:
+						if (botRec->CastID) {
+							Dest.Ptr = GetSpellByID(botRec->CastID);
+							Dest.Type = mq::datatypes::pSpellType;
+							return true;
+						}
+						break;
+					case State:
+						if (botRec->State & STATE_STUN) {
+							strcpy_s(DataTypeTemp, "STUN");
+						} else if (botRec->State & STATE_HOVER) {
+							strcpy_s(DataTypeTemp, "HOVER");
+						} else if (botRec->State & STATE_MOUNT) {
+							strcpy_s(DataTypeTemp, "MOUNT");
+						} else if (botRec->State & STATE_STAND) {
+							strcpy_s(DataTypeTemp, "STAND");
+						} else if (botRec->State & STATE_SIT) {
+							strcpy_s(DataTypeTemp, "SIT");
+						} else if (botRec->State & STATE_DUCK) {
+							strcpy_s(DataTypeTemp, "DUCK");
+						} else if (botRec->State & STATE_BIND) {
+							strcpy_s(DataTypeTemp, "BIND");
+						} else if (botRec->State & STATE_FEIGN) {
+							strcpy_s(DataTypeTemp, "FEIGN");
+						} else if (botRec->State & STATE_DEAD) {
+							strcpy_s(DataTypeTemp, "DEAD");
+						} else {
+							strcpy_s(DataTypeTemp, "UNKNOWN");
+						}
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Attacking:
+						Dest.DWord = botRec->State & STATE_ATTACK;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case AFK:
+						Dest.DWord = botRec->State & STATE_AFK;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Binding:
+						Dest.DWord = botRec->State & STATE_BIND;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Ducking:
+						Dest.DWord = botRec->State & STATE_DUCK;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Feigning:
+						Dest.DWord = botRec->State & STATE_FEIGN;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Grouped:
+						Dest.DWord = botRec->State & STATE_GROUP;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Invis:
+						Dest.DWord = botRec->State & STATE_INVIS;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Levitating:
+						Dest.DWord = botRec->State & STATE_LEV;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case LFG:
+						Dest.DWord = botRec->State & STATE_LFG;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Mounted:
+						Dest.DWord = botRec->State & STATE_MOUNT;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Moving:
+						Dest.DWord = botRec->State & STATE_MOVING;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Raid:
+						Dest.DWord = botRec->State & STATE_RAID;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Sitting:
+						Dest.DWord = botRec->State & STATE_SIT;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Standing:
+						Dest.DWord = botRec->State & STATE_STAND;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Stunned:
+						Dest.DWord = botRec->State & STATE_STUN;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Dead:
+						Dest.DWord = botRec->State & STATE_DEAD;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Hover:
+						Dest.DWord = botRec->State & STATE_HOVER;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case InvisToUndead:
+						Dest.DWord = botRec->State & STATE_ITU;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case AutoFire:
+						Dest.DWord = botRec->State & STATE_RANGED;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case HaveAggro:
+						Dest.DWord = botRec->State & STATE_HAVEAGGRO;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case WantAggro:
+						Dest.DWord = botRec->State & STATE_WANTAGGRO;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case NavigationActive:
+						Dest.DWord = botRec->State & STATE_NAVACTIVE;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case NavigationPaused:
+						Dest.DWord = botRec->State & STATE_NAVPAUSED;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case BotActive:
+						Dest.DWord = botRec->State & STATE_BOTACTIVE;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case PetAffinity:
+						Dest.DWord = botRec->State & STATE_HASPETAA;
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Extended:
+						Dest.Int = botRec->Extended;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case FreeBuffSlots:
+						Dest.Int = botRec->FreeBuff;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case InZone:
+						Dest.DWord = (pLocalPC && pLocalPC->zoneId == botRec->ZoneID && pLocalPC->instance == botRec->InstanceID);
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case InGroup:
+						Dest.DWord = IsGroupMember(botRec->Name);
+						Dest.Type = mq::datatypes::pBoolType;
+						return true;
+					case Leader:
+					case GroupLeader:
+						strcpy_s(DataTypeTemp, botRec->Leader);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Note:
+						strcpy_s(DataTypeTemp, botRec->Note);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Location:
+						strcpy_s(DataTypeTemp, botRec->Location);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case X:
+						Dest.Float = botRec->X;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case Y:
+						Dest.Float = botRec->Y;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case Z:
+						Dest.Float = botRec->Z;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case Distance:
+						Dest.Float = Get3DDistance(pLocalPlayer->X, pLocalPlayer->Y, pLocalPlayer->Z, botRec->X, botRec->Y, botRec->Z);
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case Heading:
+						strcpy_s(DataTypeTemp, botRec->Heading);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Updated:
+						Dest.Int = clock() - botRec->Updated;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case Gem:
+						if(!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0] = '\0';
+							for (int i = 0; i < NUM_SPELL_GEMS; i++) {
+								if (botRec->Gem[i]) {
+									sprintf_s(szTemp, "%d ", botRec->Gem[i]);
+									strcat_s(DataTypeTemp, szTemp);
+								} else {
+									strcat_s(DataTypeTemp, "0 ");
+								}
+							}
+							Dest.Ptr = &DataTypeTemp[0];
+							Dest.Type = mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, 0); i > 0 && i <= NUM_SPELL_GEMS) {
+								if (auto pSpell = GetSpellByID(botRec->Gem[i-1])) {
+									Dest.Ptr = pSpell;
+									Dest.Type = mq::datatypes::pSpellType;
+									return true;
+								}
+							}
+						} else {
+							for (int i = 0; i < NUM_SPELL_GEMS; i++) {
+								if (auto pSpell = GetSpellByID(botRec->Gem[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
 									}
 								}
 							}
 						}
-					}
-					return true;
-				}
-				case StacksPet:
-				{
-					Dest.Type = mq::datatypes::pBoolType;
-					Dest.DWord = false;
-					if (!ISINDEX())
-						return true;
-					PSPELL tmpSpell = NULL;
-					if (ISNUMBER())
-						tmpSpell = GetSpellByID(GETNUMBER());
-					else
-						tmpSpell = GetSpellByName(GETFIRST());
-					if (!tmpSpell)
-						return true;
-					Dest.DWord = true;
-					// Check Pet Buffs
-					for (Cpt = 0; Cpt < PETS_MAX; Cpt++) {
-						if (botRec->Pets[Cpt]) {
-							if (auto buffSpell = GetSpellByID(botRec->Pets[Cpt])) {
-								if (!NBBuffStackTest(tmpSpell, buffSpell, TRUE, FALSE) || (buffSpell == tmpSpell)) {
-									Dest.DWord = false;
+						break;					
+					case Buff:
+						if (!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0] = '\0';
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {	
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								sprintf_s(szTemp, "%d ", botRec->Buff[i]);
+								strcat_s(DataTypeTemp, szTemp);
+							}
+							Dest.Ptr = &DataTypeTemp[0];
+							Dest.Type = mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < NUM_LONG_BUFFS) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Buff[i])) {
+									Dest.Ptr = pSpell;
+									Dest.Type = mq::datatypes::pSpellType;
 									return true;
 								}
 							}
+						} else {
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Buff[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									}
+								}
+							}
 						}
+						break;
+					case Duration:
+					case BuffDuration:
+						if(!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0]=0;
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								sprintf_s(szTemp,"%d ",botRec->BDuration[i]);
+								strcat_s(DataTypeTemp,szTemp);
+							}
+							Dest.Ptr = &DataTypeTemp[0];
+							Dest.Type = mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < NUM_LONG_BUFFS) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								Dest.DWord = botRec->BDuration[i];
+								Dest.Type = mq::datatypes::pTicksType;
+								return true;
+							}
+						} else {
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Buff[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.DWord = botRec->BDuration[i];
+											Dest.Type = mq::datatypes::pTicksType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.DWord = botRec->BDuration[i];
+											Dest.Type = mq::datatypes::pTicksType;
+											return true;
+										}
+									}
+								}
+							}
+						}
+						break;
+					case ShortBuff:
+						if (!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0] = 0;
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								sprintf_s(szTemp, "%d ", botRec->Song[i]);
+								strcat_s(DataTypeTemp, szTemp);
+							}
+							Dest.Ptr = &DataTypeTemp[0];
+							Dest.Type = mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < NUM_SHORT_BUFFS) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Song[i])) {
+									Dest.Ptr = pSpell;
+									Dest.Type = mq::datatypes::pSpellType;
+									return true;
+								}
+							}
+						} else {
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Song[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									}
+								}
+							}
+						}
+						break;
+					case ShortDuration:
+						if(!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0]=0;
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								sprintf_s(szTemp,"%d ",botRec->SDuration[i]);
+								strcat_s(DataTypeTemp,szTemp);
+							}
+							Dest.Ptr=&DataTypeTemp[0];
+							Dest.Type=mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < NUM_SHORT_BUFFS) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								Dest.DWord = botRec->SDuration[i];
+								Dest.Type=mq::datatypes::pTicksType;
+								return true;
+							}
+						} else {
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Song[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.DWord = botRec->SDuration[i];
+											Dest.Type=mq::datatypes::pTicksType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.DWord = botRec->SDuration[i];
+											Dest.Type=mq::datatypes::pTicksType;
+											return true;
+										}
+									}
+								}
+							}
+						}
+						break;
+					case PetBuff:
+						if (!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0] = '\0';
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								sprintf_s(szTemp, "%d ", botRec->Pets[i]);
+								strcat_s(DataTypeTemp, szTemp);
+							}
+							Dest.Ptr = &DataTypeTemp[0];
+							Dest.Type = mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < PETS_MAX) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Pets[i])) {
+									Dest.Ptr = pSpell;
+									Dest.Type = mq::datatypes::pSpellType;
+									return true;
+								}
+							}
+						} else {
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (botRec->Pets[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Pets[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.Ptr = pSpell;
+											Dest.Type = mq::datatypes::pSpellType;
+											return true;
+										}
+									}
+								}
+							}
+						}
+						break;
+					case PetDuration:
+						if(!Index[0]) {
+							char szTemp[MAX_STRING];
+							DataTypeTemp[0]=0;
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								sprintf_s(szTemp,"%d ",botRec->PDuration[i]);
+								strcat_s(DataTypeTemp,szTemp);
+							}
+							Dest.Ptr=&DataTypeTemp[0];
+							Dest.Type=mq::datatypes::pStringType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < PETS_MAX) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								Dest.DWord = botRec->PDuration[i];
+								Dest.Type=mq::datatypes::pTicksType;
+								return true;
+							}
+						} else {
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								if (auto pSpell = GetSpellByID(botRec->Pets[i])) {
+									if (NetSimple) {
+										if (ci_find_substr(pSpell->Name, Index) != -1) {
+											Dest.DWord = botRec->PDuration[i];
+											Dest.Type=mq::datatypes::pTicksType;
+											return true;
+										}
+									} else {
+										if (!_strnicmp(Index, pSpell->Name, strlen(Index))) {
+											Dest.DWord = botRec->PDuration[i];
+											Dest.Type=mq::datatypes::pTicksType;
+											return true;
+										}
+									}
+								}
+							}
+						}
+						break;
+					case TotalAA:
+					case AAPointsTotal:
+						Dest.DWord = botRec->AAPoints + botRec->AAPointsSpent;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case UsedAA:
+					case AAPointsSpent:
+						Dest.DWord = botRec->AAPointsSpent;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case UnusedAA:
+					case AAPoints:
+						Dest.DWord = botRec->AAPoints;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case AAPointsAssigned:
+						Dest.DWord = botRec->AAPointsAssigned;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case CombatState:
+						Dest.DWord = botRec->CombatState;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case Stacks:
+						Dest.DWord = false;
+						Dest.Type = mq::datatypes::pBoolType;
+						if (!Index[0]) {
+							return true;
+						}
+						if (auto testSpell = GetSpellByName(Index)) {		// Accepts Name or ID
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Buff[i])) {
+									if ((buffSpell == testSpell) || !WillStackWith(testSpell, buffSpell)) {
+										return true;
+									}
+								}
+							}
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Song[i])) {
+									if (!IsBardSong(buffSpell) && !((IsSPAEffect(testSpell, SPA_CHANGE_FORM) && !testSpell->DurationWindow))) {
+										if ((buffSpell == testSpell) || !WillStackWith(testSpell, buffSpell)) {
+											return true;
+										}
+									}
+								}
+							}
+							Dest.DWord = true;
+						}
+						return true;
+					case StacksPet:
+						Dest.DWord = false;
+						Dest.Type = mq::datatypes::pBoolType;
+						if (!Index[0] || botRec->PetID == 0) {
+							return true;
+						}
+						if (auto testSpell = GetSpellByName(Index)) {		// Accepts Name or ID
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Pets[i])) {
+									if ((buffSpell == testSpell) || !WillStackWith(testSpell, buffSpell)) {
+										return true;
+									}
+								}
+							}
+							Dest.DWord = true;
+						}
+						return true;
+					case WillLand:
+						Dest.DWord = false;
+						Dest.Type = mq::datatypes::pBoolType;
+						if (!Index[0]) {
+							return true;
+						}
+						if (auto testSpell = GetSpellByName(Index)) {		// Accepts Name or ID
+							for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+								if (!botRec->Buff[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Buff[i])) {
+									if (!WillStackWith(testSpell, buffSpell)) {
+										return true;
+									}
+								}
+							}
+							for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+								if (!botRec->Song[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Song[i])) {
+									if (!IsBardSong(buffSpell) && !((IsSPAEffect(testSpell, SPA_CHANGE_FORM) && !testSpell->DurationWindow))) {
+										if (!WillStackWith(testSpell, buffSpell)) {
+											return true;
+										}
+									}
+								}
+							}
+							Dest.DWord = true;
+						}
+						return true;
+					case WillLandPet:
+						Dest.DWord = false;
+						Dest.Type = mq::datatypes::pBoolType;
+						if (!Index[0] || botRec->PetID == 0) {
+							return true;
+						}
+						if (auto testSpell = GetSpellByName(Index)) {		// Accepts Name or ID
+							for (int i = 0; i < PETS_MAX; i++) {
+								if (!botRec->Pets[i]) {
+									break;
+								}
+								if (auto buffSpell = GetSpellByID(botRec->Pets[i])) {
+									if (!WillStackWith(testSpell, buffSpell)) {
+										return true;
+									}
+								}
+							}
+							Dest.DWord = true;
+						}
+						return true;
+					case TooPowerfulPet:
+						if (botRec->PetID == 0) {
+							Dest.DWord = false;
+							Dest.Type = mq::datatypes::pBoolType;
+							return true;
+						}
+					case TooPowerful:		// TooPowerfulPet falls thru to here
+						Dest.DWord = false;
+						Dest.Type = mq::datatypes::pBoolType;
+						if (!Index[0]) {
+							return true;
+						}
+						if (auto pSpell = GetSpellByName(Index)) {		// Accepts Name or ID
+							if (pSpell->TargetType == TargetType_Self || pSpell->SpellType == SpellType_Detrimental || pSpell->DurationType == 0) {
+								return true;
+							}
+							int spellLevel = pSpell->GetSpellLevelNeeded(GetPcProfile()->Class);
+							if (spellLevel == 0 || spellLevel > MAX_PC_LEVEL) {
+								spellLevel = CalcMinSpellLevel(pSpell);
+							}
+							int targetLevel = botRec->Level;  			// Pet also uses Master's Level
+							if (spellLevel > 65 && targetLevel < 61) {
+								Dest.DWord = true;
+								return true;
+							}
+							if (spellLevel > 50 && targetLevel < floor(spellLevel / 2) + 15) {
+								Dest.DWord = true;
+								return true;
+							}
+						}
+						return true;
+					case Detrimentals:
+						Dest.Int64 = botRec->Detrimental[D_DETRIMENTALS];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case Counters:
+					case TotalCounters:
+						Dest.Int64 = botRec->Detrimental[D_COUNTERS];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case CountersCurse:
+						Dest.Int64 = botRec->Detrimental[D_CURSED];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case CountersDisease:
+						Dest.Int64 = botRec->Detrimental[D_DISEASED];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case CountersPoison:
+						Dest.Int64 = botRec->Detrimental[D_POISONED];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case CountersCorruption:
+						Dest.Int64 = botRec->Detrimental[D_CORRUPTED];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case NoCure:
+						Dest.Int64 = botRec->Detrimental[D_NOCURE];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case LifeDrain:
+						Dest.Int64 = botRec->Detrimental[D_LIFEDRAIN];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case ManaDrain:
+						Dest.Int64 = botRec->Detrimental[D_MANADRAIN];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case EnduDrain:
+						Dest.Int64 = botRec->Detrimental[D_ENDUDRAIN];
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case Detrimental:
+						DataTypeTemp[0] = '\0';
+						for (const auto& pair : BuffMap) {
+							if (pair.second.Type == BT_DETRIMENTAL && (botRec->DetrState & pair.second.State)) {
+								if (DataTypeTemp[0]) {
+									strcat_s(DataTypeTemp, " ");
+								}
+								strcat_s(DataTypeTemp, pair.first.c_str());
+							}
+						}
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case MacroState:
+						Dest.Int = botRec->MacroState;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case MacroName:
+						strcpy_s(DataTypeTemp, botRec->MacroName);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case FreeInventory:
+						if(!Index[0]) {
+							Dest.Int = botRec->FreeInventory[0];
+							Dest.Type = mq::datatypes::pIntType;
+							return true;
+						}
+						if (IsNumber(Index)) {
+							if (int i = GetIntFromString(Index, -1); i >= 0 && i < ISIZE) {
+								Dest.Int = botRec->FreeInventory[i];
+								Dest.Type = mq::datatypes::pIntType;
+								return true;
+							}
+						}
+						break;
+					case Version:
+						Dest.Float = botRec->Version;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case MakeCampStatus:
+						Dest.Int = botRec->MakeCampStatus;
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
+					case MakeCampX:
+						Dest.Float = botRec->MakeCampX;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case MakeCampY:
+						Dest.Float = botRec->MakeCampY;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case MakeCampRadius:
+						Dest.Float = botRec->MakeCampRadius;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case MakeCampDistance:
+						Dest.Float = botRec->MakeCampDistance;
+						Dest.Type = mq::datatypes::pFloatType;
+						return true;
+					case Lua:
+						strcpy_s(DataTypeTemp, botRec->LuaInfo);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Packets:
+						Dest.Int64 = botRec->EQBC_Packets;
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case HeartBeat:
+						Dest.Int64 = botRec->EQBC_HeartBeat;
+						Dest.Type = mq::datatypes::pInt64Type;
+						return true;
+					case Query:
+						strcpy_s(DataTypeTemp, botRec->Query);
+						Dest.Ptr = &DataTypeTemp[0];
+						Dest.Type = mq::datatypes::pStringType;
+						return true;
+					case Slowed:
+					case Rooted:
+					case Mesmerized:
+					case Crippled:
+					case Maloed:
+					case Tashed:
+					case Snared:
+					case RevDSed:
+					case Charmed:
+					case Diseased:
+					case Poisoned:
+					case Cursed:
+					case Corrupted:
+					case Blinded:
+					case CastingLevel:
+					case Feared:
+					case Healing:
+					case Invulnerable:
+					case Resistance:
+					case Silenced:
+					case SpellCost:
+					case SpellDamage:
+					case SpellSlowed:
+					case Trigger:
+					case DSed:
+					case Aego:
+					case Skin:
+					case Focus:
+					case Regen:
+					case Symbol:
+					case Clarity:
+					case Pred:
+					case Strength:
+					case Brells:
+					case SV:
+					case SE:
+					case HybridHP:
+					case Growth:
+					case Shining:
+					case Hasted: {
+						auto f = BuffMap.find(pMember->Name);
+						Dest.Int = ((f != BuffMap.end()) && 
+									((f->second.Type == BT_DETRIMENTAL && (botRec->DetrState & f->second.State)) ||
+									 (f->second.Type == BT_BENEFICIAL  && (botRec->BeneState & f->second.State)))); 
+						Dest.Type = mq::datatypes::pIntType;
+						return true;
 					}
-					return true;
-				}
-				case Detrimentals:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[DETRIMENTALS];
-					return true;
-				case Counters:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[COUNTERS];
-					return true;
-				case Cursed:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[CURSED];
-					return true;
-				case Diseased:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[DISEASED];
-					return true;
-				case Poisoned:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[POISONED];
-					return true;
-				case Corrupted:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[CORRUPTED];
-					return true;
-				case EnduDrain:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[ENDUDRAIN];
-					return true;
-				case LifeDrain:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[LIFEDRAIN];
-					return true;
-				case ManaDrain:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[MANADRAIN];
-					return true;
-				case Blinded:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[BLINDED];
-					return true;
-				case CastingLevel:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[CASTINGLEVEL];
-					return true;
-				case Charmed:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[CHARMED];
-					return true;
-				case Feared:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[FEARED];
-					return true;
-				case Healing:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[HEALING];
-					return true;
-				case Invulnerable:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[INVULNERABLE];
-					return true;
-				case Mesmerized:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[MESMERIZED];
-					return true;
-				case Rooted:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[ROOTED];
-					return true;
-				case Silenced:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SILENCED];
-					return true;
-				case Slowed:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SLOWED];
-					return true;
-				case Snared:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SNARED];
-					return true;
-				case SpellCost:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SPELLCOST];
-					return true;
-				case SpellSlowed:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SPELLSLOWED];
-					return true;
-				case SpellDamage:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[SPELLDAMAGE];
-					return true;
-				case Trigger:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[TRIGGR];
-					return true;
-				case Resistance:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[RESISTANCE];
-					return true;
-				case Detrimental:
-					Temps[0] = 0;
-					if (botRec->Detrimental[CURSED])       strcat_s(Temps, "Cursed ");
-					if (botRec->Detrimental[DISEASED])     strcat_s(Temps, "Diseased ");
-					if (botRec->Detrimental[POISONED])     strcat_s(Temps, "Poisoned ");
-					if (botRec->Detrimental[ENDUDRAIN])    strcat_s(Temps, "EnduDrain ");
-					if (botRec->Detrimental[LIFEDRAIN])    strcat_s(Temps, "LifeDrain ");
-					if (botRec->Detrimental[MANADRAIN])    strcat_s(Temps, "ManaDrain ");
-					if (botRec->Detrimental[BLINDED])      strcat_s(Temps, "Blinded ");
-					if (botRec->Detrimental[CASTINGLEVEL]) strcat_s(Temps, "CastingLevel ");
-					if (botRec->Detrimental[CHARMED])      strcat_s(Temps, "Charmed ");
-					if (botRec->Detrimental[FEARED])       strcat_s(Temps, "Feared ");
-					if (botRec->Detrimental[HEALING])      strcat_s(Temps, "Healing ");
-					if (botRec->Detrimental[INVULNERABLE]) strcat_s(Temps, "Invulnerable ");
-					if (botRec->Detrimental[MESMERIZED])   strcat_s(Temps, "Mesmerized ");
-					if (botRec->Detrimental[ROOTED])       strcat_s(Temps, "Rooted ");
-					if (botRec->Detrimental[SILENCED])     strcat_s(Temps, "Silenced ");
-					if (botRec->Detrimental[SLOWED])       strcat_s(Temps, "Slowed ");
-					if (botRec->Detrimental[SNARED])       strcat_s(Temps, "Snared ");
-					if (botRec->Detrimental[SPELLCOST])    strcat_s(Temps, "SpellCost ");
-					if (botRec->Detrimental[SPELLDAMAGE])  strcat_s(Temps, "SpellDamage ");
-					if (botRec->Detrimental[SPELLSLOWED])  strcat_s(Temps, "SpellSlowed ");
-					if (botRec->Detrimental[TRIGGR])       strcat_s(Temps, "Trigger ");
-					if (botRec->Detrimental[CORRUPTED])    strcat_s(Temps, "Corrupted ");
-					if (botRec->Detrimental[RESISTANCE])   strcat_s(Temps, "Resistance ");
-					if (size_t len = strlen(Temps)) Temps[--len] = 0;
-					Dest.Type = mq::datatypes::pStringType;
-					Dest.Ptr = Temps;
-					return true;
-				case NoCure:
-					Dest.Type = mq::datatypes::pIntType;
-					Dest.Int = botRec->Detrimental[NOCURE];
-					return true;
-
+					case Spell: {
+						if (!Index[0] || IsNumber(Index)) {
+							break;
+						}
+						int bType = 0;
+						int sType = 0;
+						auto f = BuffMap.find(Index);
+						if (f != BuffMap.end()) {
+							if ((f->second.Type == BT_DETRIMENTAL && (botRec->DetrState & f->second.State)) ||
+								(f->second.Type == BT_BENEFICIAL  && (botRec->BeneState & f->second.State))) {
+								bType = f->second.Type;
+								sType = f->second.SpellType;
+							}
+						}
+						if (!sType) {
+							break;
+						}
+						int sResult = -1;
+						for (int i = 0; i < NUM_LONG_BUFFS; i++) {
+							if (!botRec->Buff[i]) {
+								break;
+							}
+							if (auto pSpell = GetSpellByID(botRec->Buff[i])) {
+								if ((pSpell->SpellType == SpellType_Detrimental) == (bType == BT_DETRIMENTAL)) {
+									if (CheckBotSpell(pSpell, sType)) {
+										sResult = i;
+										break;
+									}
+								}
+							}
+						}
+						if (sResult >= 0) {
+							if (auto pSpell = GetSpellByID(botRec->Buff[sResult])) {
+								Dest.Ptr = pSpell;
+								Dest.Type = mq::datatypes::pSpellType;
+								return true;
+							}
+							break;
+						}
+						for (int i = 0; i < NUM_SHORT_BUFFS; i++) {
+							if (!botRec->Song[i]) {
+								break;
+							}
+							if (auto pSpell = GetSpellByID(botRec->Song[i])) {
+								if ((pSpell->SpellType == SpellType_Detrimental) == (bType == BT_DETRIMENTAL)) {
+									if (CheckBotSpell(pSpell, sType)) {
+										sResult = i;
+										break;
+									}
+								}
+							}
+						}
+						if (sResult >= 0) {
+							if (auto pSpell = GetSpellByID(botRec->Song[sResult])) {
+								Dest.Ptr = pSpell;
+								Dest.Type = mq::datatypes::pSpellType;
+								return true;
+							}
+							break;
+						}
+						break;
+					}
+					default:
+						break;
 				}
 			}
 		}
-		strcpy_s(Temps, "NULL");
+		strcpy_s(DataTypeTemp, "NULL");
+		Dest.Ptr = &DataTypeTemp[0];
 		Dest.Type = mq::datatypes::pStringType;
-		Dest.Ptr = Temps;
-		return true;
-	}
-
-	bool ToString(MQVarPtr VarPtr, PCHAR Destination) {
-		strcpy_s(Destination, MAX_STRING, "TRUE");
 		return true;
 	}
 
@@ -1715,80 +3047,235 @@ public:
 
 bool dataNetBots(const char* szIndex, MQTypeVar& Ret) {
 	Ret.Type = pNetBotsType;
-	if (szIndex != nullptr && szIndex[0] != '\0')
-	{
+	if (szIndex != nullptr && szIndex[0] != '\0') {
 		auto f = NetMap.find(szIndex);
-		if (f != NetMap.end())
-		{
+		if (f != NetMap.end()) {
 			Ret.Set(f->second);
 			return true;
 		}
 		return false;
 	}
-
 	return true;
 }
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
 
-void Command(PSPAWNINFO pChar, PCHAR Cmd) {
-	char Tmp[MAX_STRING]; BYTE Parm = 1;
-	char Var[MAX_STRING];
-	char Set[MAX_STRING];
-	do {
-		GetArg(Tmp, Cmd, Parm++);
-		GetArg(Var, Tmp, 1, FALSE, FALSE, FALSE, '=');
-		GetArg(Set, Tmp, 2, FALSE, FALSE, FALSE, '=');
-		if (!_strnicmp(Tmp, "on", 2) || !_strnicmp(Tmp, "off", 3)) {
-			NetStat = _strnicmp(Tmp, "off", 3);
-			WritePrivateProfileString(PLUGIN_NAME, "Stat", NetStat ? "1" : "0", INIFileName);
-		}
-		else if (!_strnicmp(Var, "stat", 4) || !_strnicmp(Var, "plugin", 6)) {
-			NetStat = _strnicmp(Set, "off", 3);
-			WritePrivateProfileString(PLUGIN_NAME, "Stat", NetStat ? "1" : "0", INIFileName);
+void WriteWindowINI(CSidlScreenWnd* pWindow);
+void ReadWindowINI(CSidlScreenWnd* pWindow);
+void DestroyMyWindow();
+void CreateMyWindow();
+void HideMyWindow();
+void ShowMyWindow();
+void WindowUpdate();
 
-		}
-		else if (!_strnicmp(Var, "grab", 4)) {
-			NetGrab = _strnicmp(Set, "off", 3);
-			WritePrivateProfileString(PLUGIN_NAME, "Grab", NetGrab ? "1" : "0", INIFileName);
-		}
-		else if (!_strnicmp(Var, "send", 4)) {
-			NetSend = _strnicmp(Set, "off", 3);
-			WritePrivateProfileString(PLUGIN_NAME, "Send", NetSend ? "1" : "0", INIFileName);
-		}
-	} while (strlen(Tmp));
-	WriteChatf("%s:: (%s) Grab (%s) Send (%s).", PLUGIN_NAME, NetStat ? "\agon\ax" : "\aroff\ax", NetGrab ? "\agon\ax" : "\aroff\ax", NetSend ? "\agon\ax" : "\aroff\ax");
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
+
+void LoadINIValues() {
+	char szTemp[MAX_STRING] = { 0 };
+	int oldUseNewWindow = NetUseNewWindow;
+	
+	GetPrivateProfileString("Settings", "Query",       "", NetQuery,       MAX_STRING, GlobalINIFileName);
+	GetPrivateProfileString("Settings", "WindowTitle", "", NetWindowTitle, MAX_STRING, GlobalINIFileName);
+	// Handle empty title as 1/Default.
+	if (!NetWindowTitle[0]) {
+		strcpy_s(NetWindowTitle, "1");
+	}
+	
+	NetStat         = GetPrivateProfileInt(PLUGIN_NAME, "Stat",            0, INIFileName);
+	NetGrab         = GetPrivateProfileInt(PLUGIN_NAME, "Grab",            0, INIFileName);
+	NetSend         = GetPrivateProfileInt(PLUGIN_NAME, "Send",            0, INIFileName);
+	NetSimple       = GetPrivateProfileInt(PLUGIN_NAME, "UseSimpleSearch", 0, INIFileName);
+	NetShow         = GetPrivateProfileInt(PLUGIN_NAME, "Show",            0, INIFileName);
+	NetUseNewWindow = GetPrivateProfileInt(PLUGIN_NAME, "UseNewWindow",    1, INIFileName);
+	NetConColors    = GetPrivateProfileInt(PLUGIN_NAME, "ConColors",       0, INIFileName);
+	NetCleanNames   = GetPrivateProfileInt(PLUGIN_NAME, "CleanNames",      0, INIFileName);
+	NetEQBCData     = GetPrivateProfileInt(PLUGIN_NAME, "SendEQBCData",    0, INIFileName);
+	NetExtended     = std::clamp(GetPrivateProfileInt(PLUGIN_NAME, "Extended",        0, INIFileName), 0, EXSIZE - 1);
+	NetLClick       = std::clamp(GetPrivateProfileInt(PLUGIN_NAME, "LClick",          0, INIFileName), 0, CASIZE - 1);
+	NetRClick       = std::clamp(GetPrivateProfileInt(PLUGIN_NAME, "RClick",          0, INIFileName), 0, CASIZE - 1);
+	NetRightMost    = std::clamp(GetPrivateProfileInt(PLUGIN_NAME, "TargetRightMost", 0, INIFileName), 0, EQ_MAX_NAME);
+
+	WritePrivateProfileString("Settings",  "Query",           NetQuery,       GlobalINIFileName);
+	WritePrivateProfileString("Settings",  "WindowTitle",     NetWindowTitle, GlobalINIFileName);
+	
+	WritePrivateProfileInt(PLUGIN_NAME, "Stat",            NetStat ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "Grab",            NetGrab ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "Send",            NetSend ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "UseSimpleSearch", NetSimple ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "Show",            NetShow ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "UseNewWindow",    NetUseNewWindow ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "ConColors",       NetConColors ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "CleanNames",      NetCleanNames ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "SendEQBCData",    NetEQBCData ? 1 : 0, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "Extended",        NetExtended, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "LClick",          NetLClick, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "RClick",          NetRClick, INIFileName);
+	WritePrivateProfileInt(PLUGIN_NAME, "TargetRightMost", NetRightMost, INIFileName);
+
+	// WindowTItle - 0=None, 1=Default, anything else is as-entered. Empty is treated as 1/Default (see above).
+	if (!_stricmp(NetWindowTitle, "0")) {
+		NetWindowTitle[0] = '\0';
+	} else if (!_stricmp(NetWindowTitle, "1")) {
+		sprintf_s(NetWindowTitle, "%s (${NetBots.Counts})", PLUGIN_NAME);
+	}
+	if (NetUseNewWindow != oldUseNewWindow) {
+		DestroyMyWindow();
+	}
+	if (NetShow) {
+		ShowMyWindow();
+	}
 }
 
-void CommandNote(PSPAWNINFO pChar, PCHAR Cmd) {
+void Command(PlayerClient* pChar, const char* Cmd) {
+	char szTemp[MAX_STRING];
+	char Var[MAX_STRING];
+	char Set[MAX_STRING];
+	int Parm = 1;
+	do {
+		GetArg(szTemp, Cmd, Parm++);
+		GetArg(Var, szTemp, 1, FALSE, FALSE, FALSE, '=');
+		GetArg(Set, szTemp, 2, FALSE, FALSE, FALSE, '=');
+		if (!_stricmp(szTemp, "show")) {
+			NetShow = 1;
+			WritePrivateProfileInt(PLUGIN_NAME, "Show", NetShow, INIFileName);
+			ShowMyWindow();
+			return;
+		}
+		if (!_stricmp(szTemp, "hide")) {
+			NetShow = 0;
+			WritePrivateProfileInt(PLUGIN_NAME, "Show", NetShow, INIFileName);
+			HideMyWindow();
+			return;
+		}
+		if (!_stricmp(szTemp, "switch")) {
+			DestroyMyWindow();
+			NetUseNewWindow = (NetUseNewWindow ? 0 : 1);
+	        WritePrivateProfileInt(PLUGIN_NAME, "UseNewWindow", NetUseNewWindow, INIFileName);
+			if (NetShow) {
+				ShowMyWindow();
+			}
+			return;
+		}
+		if (!_stricmp(szTemp, "on") || !_stricmp(szTemp, "off")) {
+			NetStat = _stricmp(szTemp, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "Stat", NetStat ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "stat") || !_stricmp(Var, "plugin")) {
+			NetStat = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "Stat", NetStat ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "grab")) {
+			NetGrab = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "Grab", NetGrab ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "send")) {
+			NetSend = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "Send", NetSend ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "extended") || !_stricmp(Var, "ext")) {
+			// Support old off/on values as 0/1
+			if (!_stricmp(Set, "off")) {
+				NetExtended = 0;
+			} else if (!_stricmp(Set, "on")) {
+				NetExtended = 1;
+			} else {
+				NetExtended = std::clamp(GetIntFromString(Set, 0), 0, EXSIZE - 1);
+			}
+			WritePrivateProfileInt(PLUGIN_NAME, "Extended", NetExtended, INIFileName);
+		} else if (!_stricmp(Var, "usesimplesearch") || !_stricmp(Var, "simple")) {
+			NetSimple = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "UseSimpleSearch", NetSimple ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "LClick")) {
+			if (!_stricmp(Set, "foreground")) {
+				NetLClick = CA_BRING_TO_FOREGROUND;
+			} else if (!_stricmp(Set, "target")) {
+				NetLClick = CA_TARGET_PLAYER;
+			} else if (!_stricmp(Set, "tot")) {
+				NetLClick = CA_TARGET_PLAYER_TARGET;
+			} else {
+				NetLClick = std::clamp(GetIntFromString(Set, 0), 0, CASIZE - 1);
+			}
+			WritePrivateProfileInt(PLUGIN_NAME, "LClick", NetLClick, INIFileName);
+		} else if (!_stricmp(Var, "RClick")) {
+			if (!_stricmp(Set, "foreground")) {
+				NetRClick = CA_BRING_TO_FOREGROUND;
+			} else if (!_stricmp(Set, "target")) {
+				NetRClick = CA_TARGET_PLAYER;
+			} else if (!_stricmp(Set, "tot")) {
+				NetRClick = CA_TARGET_PLAYER_TARGET;
+			} else {
+				NetRClick = std::clamp(GetIntFromString(Set, 0), 0, CASIZE - 1);
+			}
+			WritePrivateProfileInt(PLUGIN_NAME, "RClick", NetRClick, INIFileName);
+		} else if (!_stricmp(Var, "concolors")) {
+			NetConColors = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "ConColors", NetConColors ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "cleannames")) {
+			NetCleanNames = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "CleanNames", NetCleanNames ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "targetrightmost") || !_stricmp(Var, "rightmost")) {
+			NetRightMost = std::clamp(GetIntFromString(Set, 0), 0, EQ_MAX_NAME);
+			WritePrivateProfileInt(PLUGIN_NAME, "TargetRightMost", NetRightMost, INIFileName);
+		} else if (!_stricmp(Var, "sendeqbcdata")) {
+			NetEQBCData = _stricmp(Set, "off");
+			WritePrivateProfileInt(PLUGIN_NAME, "SendEQBCData", NetEQBCData ? 1 : 0, INIFileName);
+		} else if (!_stricmp(Var, "load")) {
+			LoadINIValues();
+		}
+	} while (strlen(szTemp));
+
+	WriteChatf("%s:: (%s) Grab (%s) Send (%s) Extended (\at%d\ax) Simple (%s) Show (%s). Version=\at%.2f",
+				PLUGIN_NAME,
+				NetStat ? "\agon\ax" : "\aroff\ax",
+				NetGrab ? "\agon\ax" : "\aroff\ax",
+				NetSend ? "\agon\ax" : "\aroff\ax",
+				NetExtended,
+				NetSimple ? "\agon\ax" : "\aroff\ax",
+				NetShow ? "\agon\ax" : "\aroff\ax",
+				MQ2Version);
+
+	if (NetShow) {			
+		WriteChatf("%s:: ConColors (%s) CleanNames (%s) RightMost (\at%d\ax). LClick=\at%s\ax, RClick=\at%s\ax.",
+				PLUGIN_NAME,
+				NetConColors ? "\agon\ax" : "\aroff\ax",
+				NetCleanNames ? "\agon\ax" : "\aroff\ax",
+				NetRightMost,
+				(NetLClick == CA_BRING_TO_FOREGROUND) ? "1/Foreground" : (NetLClick == CA_TARGET_PLAYER) ? "2/Target" : (NetLClick == CA_TARGET_PLAYER_TARGET) ? "3/ToT" : "0/None",
+				(NetRClick == CA_BRING_TO_FOREGROUND) ? "1/Foreground" : (NetRClick == CA_TARGET_PLAYER) ? "2/Target" : (NetRClick == CA_TARGET_PLAYER_TARGET) ? "3/ToT" : "0/None");
+	}
+}
+
+void CommandNote(PlayerClient* pChar, const char* Cmd) {
 	strcpy_s(NetNote, Cmd);
 }
 
 //=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
 
-PLUGIN_API VOID OnBeginZone(VOID) {
-#if    DEBUGGING>0
-	DebugSpewAlways("%s->OnBeginZone()", PLUGIN_NAME);
-#endif DEBUGGING
+PLUGIN_API void OnBeginZone() {
+	if (DEBUGGING) {
+		DebugSpewAlways("%s->OnBeginZone()", PLUGIN_NAME);
+	}
 	ZeroMemory(sTimers, sizeof(sTimers));
-	if (NetStat && NetSend && EQBCConnected()) EQBCBroadCast("[NB]|Z=:>|[NB]");
+	if (NetStat && NetSend && EQBCConnected()) {
+		EQBCBroadCast("[NB]|Z=:>|[NB]");
+	}
 }
 
-PLUGIN_API VOID OnNetBotEVENT(PCHAR Msg) {
-#if    DEBUGGING>0
-	DebugSpewAlways("%s->OnNetBotEVENT(%s)", PLUGIN_NAME, Msg);
-#endif DEBUGGING
-	if (!strncmp(Msg, "NBQUIT=", 7))      BotQuit(&Msg[7]);
-	else if (!strncmp(Msg, "NBJOIN=", 7)) ZeroMemory(sTimers, sizeof(sTimers));
-	else if (!strncmp(Msg, "NBEXIT", 6))  NetMap.clear();
+PLUGIN_API void OnNetBotEVENT(const char* Msg) {
+	if (DEBUGGING) {
+		DebugSpewAlways("%s->OnNetBotEVENT(%s)", PLUGIN_NAME, Msg);
+	}
+	if (!strncmp(Msg, "NBQUIT=", 7)) {
+		BotQuit(&Msg[7]);
+	} else if (!strncmp(Msg, "NBJOIN=", 7)) {
+		ZeroMemory(sTimers, sizeof(sTimers));
+	} else if (!strncmp(Msg, "NBEXIT", 6)) {
+		NetMap.clear();
+	}
 }
 
-PLUGIN_API VOID OnNetBotMSG(PCHAR Name, PCHAR Msg) {
-	if (NetStat && NetGrab && !strncmp(Msg, "[NB]|", 5) && GetCharInfo() && GetCharInfo()->pSpawn && strcmp(GetCharInfo()->Name, Name)) {
-#if    DEBUGGING>1
-		DebugSpewAlways("%s->OnNetBotMSG(From:[%s] Msg[%s])", PLUGIN_NAME, Name, Msg);
-#endif DEBUGGING
-		CHAR szCmd[MAX_STRING] = { 0 };
+PLUGIN_API void OnNetBotMSG(const char* Name, const char* Msg) {
+	if (NetStat && NetGrab && !strncmp(Msg, "[NB]|", 5) && pLocalPC && pLocalPlayer && strcmp(pLocalPC->Name, Name)) {
+		if (DEBUGGING) {
+			DebugSpewAlways("%s->OnNetBotMSG(From:[%s] Msg[%s])", PLUGIN_NAME, Name, Msg);
+		}
+		char szCmd[MAX_STRING] = { 0 };
 		strcpy_s(szCmd, Msg);
 		if (CurBot = BotLoad(Name).get()) {
 			Packet.Feed(szCmd);
@@ -1798,76 +3285,320 @@ PLUGIN_API VOID OnNetBotMSG(PCHAR Name, PCHAR Msg) {
 	}
 }
 
-PLUGIN_API VOID OnPulse(VOID) {
-	if (NetStat && NetSend && gbInZone && (long)clock() > NetLast) {
-		NetLast = (long)clock() + NETTICK;
-		if (EQBCConnected() && GetCharInfo() && GetCharInfo()->pSpawn && GetPcProfile()) BroadCast();
+PLUGIN_API void OnPulse() {
+	if (NetStat && NetSend && gbInZone && (int)clock() > NetLast) {
+		NetLast = (int)clock() + NETTICK;
+		if (EQBCConnected() && pLocalPC && pLocalPlayer && GetPcProfile()) {
+			BroadCast();
+		}
+	}
+	if (NetShow && NetStat && NetSend && MQGetTickCount64() > ShowTime) {
+		WindowUpdate();
 	}
 }
 
-PLUGIN_API VOID SetGameState(DWORD GameState) {
-#if    DEBUGGING>0
-	DebugSpewAlways("%s->SetGameState(%d)", PLUGIN_NAME, GameState);
-#endif DEBUGGING
+PLUGIN_API void SetGameState(int GameState) {
+	if (DEBUGGING) {
+		DebugSpewAlways("%s->SetGameState(%d)", PLUGIN_NAME, GameState);
+	}
 	if (GameState == GAMESTATE_INGAME) {
 		if (!NetInit) {
-#if    DEBUGGING>0
-			DebugSpewAlways("%s->SetGameState(%d)->Loading", PLUGIN_NAME, GameState);
-#endif DEBUGGING
+			if (DEBUGGING) {
+				DebugSpewAlways("%s->SetGameState(%d)->Loading", PLUGIN_NAME, GameState);
+			}
+			sprintf_s(GlobalINIFileName, "%s\\%s.ini", gPathConfig, PLUGIN_NAME);
 			sprintf_s(INIFileName, "%s\\%s_%s.ini", gPathConfig, GetServerShortName(), pLocalPC->Name);
-			NetStat = GetPrivateProfileInt(PLUGIN_NAME, "Stat", 0, INIFileName);
-			NetGrab = GetPrivateProfileInt(PLUGIN_NAME, "Grab", 0, INIFileName);
-			NetSend = GetPrivateProfileInt(PLUGIN_NAME, "Send", 0, INIFileName);
-			NetInit = true;
+			sprintf_s(PlayerSectionName, "%s.%s", GetServerShortName(), pLocalPC->Name);
+			LoadINIValues();
+			NetInit = 1;
 		}
-	}
-	else if (GameState != GAMESTATE_LOGGINGIN) {
+	} else if (GameState != GAMESTATE_LOGGINGIN) {
 		if (NetInit) {
-#if    DEBUGGING>0
-			DebugSpewAlways("%s->SetGameState(%d)->Flushing", PLUGIN_NAME, GameState);
-#endif DEBUGGING
-			NetStat = false;
-			NetGrab = false;
-			NetSend = false;
-			NetInit = false;
+			if (DEBUGGING) {
+				DebugSpewAlways("%s->SetGameState(%d)->Flushing", PLUGIN_NAME, GameState);
+			}
+			NetStat = 0;
+			NetGrab = 0;
+			NetSend = 0;
+			NetExtended = 0;
+			NetShow = 0;
+			NetUseNewWindow = -1;
+			NetLClick = 0;
+			NetRClick = 0;
+			NetConColors = 0;
+			NetCleanNames = 0;
+			NetRightMost = 0;
+			NetEQBCData = 0;
+			NetInit = 0;
 		}
 	}
 }
 
-PLUGIN_API VOID InitializePlugin(VOID) {
-#if    DEBUGGING>0
-	DebugSpewAlways("%s->ShutdownPlugin()", PLUGIN_NAME);
-#endif DEBUGGING
-	Packet.Reset();
-	NetMap.clear();
-	Packet.AddEvent("#*#[NB]#*#|Z=#1#:#2#>#3#|#*#[NB]", ParseInfo, (void *)3);
-	Packet.AddEvent("#*#[NB]#*#|L=#4#:#5#|#*#[NB]", ParseInfo, (void *)5);
-	Packet.AddEvent("#*#[NB]#*#|H=#6#/#7#|#*#[NB]", ParseInfo, (void *)7);
-	Packet.AddEvent("#*#[NB]#*#|E=#8#/#9#|#*#[NB]", ParseInfo, (void *)9);
-	Packet.AddEvent("#*#[NB]#*#|M=#10#/#11#|#*#[NB]", ParseInfo, (void *)11);
-	Packet.AddEvent("#*#[NB]#*#|P=#12#:#13#|#*#[NB]", ParseInfo, (void *)13);
-	Packet.AddEvent("#*#[NB]#*#|T=#14#:#15#|#*#[NB]", ParseInfo, (void *)15);
-	Packet.AddEvent("#*#[NB]#*#|C=#16#|#*#[NB]", ParseInfo, (void *)16);
-	Packet.AddEvent("#*#[NB]#*#|Y=#17#|#*#[NB]", ParseInfo, (void *)17);
+void __stdcall ParseInfo(unsigned int ID, void *pData, PBLECHVALUE pValues) {
+	if (CurBot) while (pValues) {
+		switch (GetIntFromString(pValues->Name, 0)) {
+			case  1:
+				CurBot->ZoneID = GetIntFromString(pValues->Value, 0);
+				break;
+			case  2:
+				CurBot->InstanceID = GetIntFromString(pValues->Value, 0);
+				break;
+			case  3:
+				CurBot->SpawnID = GetIntFromString(pValues->Value, 0);
+				break;
+			case  4:
+				CurBot->Level = GetIntFromString(pValues->Value, 0);
+				break;
+			case  5:
+				CurBot->ClassID = GetIntFromString(pValues->Value, 0);
+				break;
+			case  6:
+				CurBot->HPCurrent = GetIntFromString(pValues->Value, 0);
+				break;
+			case  7:
+				CurBot->HPMax = GetIntFromString(pValues->Value, 0);
+				break;
+			case  8:
+				CurBot->EnduranceCurrent = GetIntFromString(pValues->Value, 0);
+				break;
+			case  9:
+				CurBot->EnduranceMax = GetIntFromString(pValues->Value, 0);
+				break;
+			case 10:
+				CurBot->ManaCurrent = GetIntFromString(pValues->Value, 0);
+				break;
+			case 11:
+				CurBot->ManaMax = GetIntFromString(pValues->Value, 0);
+				break;
+			case 12:
+				CurBot->PetID = GetIntFromString(pValues->Value, 0);
+				break;
+			case 13:
+				CurBot->PetHPPct = GetIntFromString(pValues->Value, 0);
+				break;
+			case 14:
+				CurBot->TargetID = GetIntFromString(pValues->Value, 0);
+				break;
+			case 15:
+				CurBot->TargetHPPct = GetIntFromString(pValues->Value, 0);
+				break;
+			case 16:
+				CurBot->CastID = GetIntFromString(pValues->Value, 0);
+				break;
+			case 17:
+				CurBot->State = (uint32_t)GetIntFromString(pValues->Value, 0);
+				break;
+			case 18:
+				CurBot->Exp = (int64_t)GetIntFromString(pValues->Value, 0);
+				break;
+			case 19:
+				CurBot->AAExp = (uint32_t)GetIntFromString(pValues->Value, 0);
+				break;
 #if HAS_LEADERSHIP_EXPERIENCE
-	Packet.AddEvent("#*#[NB]#*#|X=#18#:#19#:#20#|#*#[NB]", ParseInfo, (void *)20);
-#else
-	Packet.AddEvent("#*#[NB]#*#|X=#18#:#19#|#*#[NB]", ParseInfo, (void *)19);
+			case 20:
+				CurBot->GroupLeaderExp = GetDoubleFromString(pValues->Value, 0.0);
+				break;
 #endif
-	Packet.AddEvent("#*#[NB]#*#|F=#21#:|#*#[NB]", ParseInfo, (void *)21);
-	Packet.AddEvent("#*#[NB]#*#|N=#22#|#*#[NB]", ParseInfo, (void *)22);
-	Packet.AddEvent("#*#[NB]#*#|G=#30#|#*#[NB]", ParseInfo, (void *)30);
-	Packet.AddEvent("#*#[NB]#*#|B=#31#|#*#[NB]", ParseInfo, (void *)31);
-	Packet.AddEvent("#*#[NB]#*#|S=#32#|#*#[NB]", ParseInfo, (void *)32);
-	Packet.AddEvent("#*#[NB]#*#|W=#33#|#*#[NB]", ParseInfo, (void *)33);
-	Packet.AddEvent("#*#[NB]#*#|D=#34#|#*#[NB]", ParseInfo, (void *)34);
-	Packet.AddEvent("#*#[NB]#*#|A=#35#:#36#:#37#|#*#[NB]", ParseInfo, (void *)37);
-	Packet.AddEvent("#*#[NB]#*#|O=#38#|#*#[NB]", ParseInfo, (void *)38);
-	Packet.AddEvent("#*#[NB]#*#|U=#39#|#*#[NB]", ParseInfo, (void *)39);
-	Packet.AddEvent("#*#[NB]#*#|R=#40#|#*#[NB]", ParseInfo, (void *)40);
-	Packet.AddEvent("#*#[NB]#*#|@=#89#|#*#[NB]", ParseInfo, (void *)89);
-	Packet.AddEvent("#*#[NB]#*#|$=#90#|#*#[NB]", ParseInfo, (void *)90);
+			case 21:
+				CurBot->FreeBuff = GetIntFromString(pValues->Value, 0);
+				break;
+			case 22:
+				strcpy_s(CurBot->Leader, pValues->Value.c_str());
+				break;
+			case 30: 
+				InfoGems(CurBot, pValues->Value.c_str());
+				break;
+			case 31:
+				InfoBuff(CurBot, pValues->Value.c_str());
+				break;
+			case 32:
+				InfoSong(CurBot, pValues->Value.c_str());
+				break;
+			case 33:
+				InfoPets(CurBot, pValues->Value.c_str());
+				break;
+			case 34:
+				InfoBDura(CurBot, pValues->Value.c_str());
+				break;
+			case 35:
+				CurBot->AAPoints = GetIntFromString(pValues->Value, 0);
+				break;
+			case 36:
+				CurBot->AAPointsSpent = GetIntFromString(pValues->Value, 0);
+				break;
+			case 37:
+				CurBot->AAPointsAssigned = GetIntFromString(pValues->Value, 0);
+				break;
+			case 38:
+				CurBot->CombatState = GetIntFromString(pValues->Value, 0);
+				break;
+			case 39:
+				strcpy_s(CurBot->Note, pValues->Value.c_str());
+				break;
+			case 40:
+				InfoDetr(CurBot, pValues->Value.c_str());
+				break;
+			case 89:
+				InfoLoc(CurBot, pValues->Value.c_str());
+				break;
+			case 90:
+				strcpy_s(CurBot->Heading, pValues->Value.c_str());
+				break;
+			case 91:
+				CurBot->Extended = GetIntFromString(pValues->Value, 0);
+				break;
+			case 94:
+				CurBot->MacroState = GetIntFromString(pValues->Value, 0);
+				break;
+			case 95:
+				strcpy_s(CurBot->MacroName, pValues->Value.c_str());
+				break;
+			case 110: 
+				InfoFreeI(CurBot, pValues->Value.c_str());
+				break;
+			case 111:
+				CurBot->Version = GetFloatFromString(pValues->Value, 0);
+				break;
+			case 112:
+				CurBot->MakeCampStatus = GetIntFromString(pValues->Value, 0);
+				break;
+			case 113:
+				CurBot->MakeCampX = GetFloatFromString(pValues->Value, 0);
+				break;
+			case 114:
+				CurBot->MakeCampY = GetFloatFromString(pValues->Value, 0);
+				break;
+			case 115:
+				CurBot->MakeCampRadius = GetFloatFromString(pValues->Value, 0);
+				break;
+			case 116:
+				CurBot->MakeCampDistance = GetFloatFromString(pValues->Value, 0);
+				break;
+			case 117:
+				strcpy_s(CurBot->LuaInfo, pValues->Value.c_str());
+				break;
+			case 118:
+				CurBot->EQBC_Packets = GetUInt64FromString(pValues->Value, 0);
+			case 119:
+				CurBot->EQBC_HeartBeat = GetUInt64FromString(pValues->Value, 0);
+			case 120:
+				strcpy_s(CurBot->Query, pValues->Value.c_str());
+				break;
+			case 121:
+				CurBot->DetrState = (uint32_t)GetIntFromString(pValues->Value, 0);
+				break;
+			case 122:
+				CurBot->BeneState = (uint32_t)GetIntFromString(pValues->Value, 0);
+				break;
+			case 123:
+				InfoSDura(CurBot, pValues->Value.c_str());
+				break;
+			case 124:
+				InfoPDura(CurBot, pValues->Value.c_str());
+				break;
+			default:
+				break;
+		}
+		pValues = pValues->pNext;
+	}
+}
 
+void LoadEvents() {
+	Packet.Reset();
+	Packet.AddEvent("#*#[NB]#*#|Z=#1#:#2#>#3#|#*#[NB]",                   ParseInfo, (void *)3);	// ZoneID, InstanceID, SpawnID
+	Packet.AddEvent("#*#[NB]#*#|L=#4#:#5#|#*#[NB]",                       ParseInfo, (void *)5);	// Level, ClassID
+	Packet.AddEvent("#*#[NB]#*#|H=#6#/#7#|#*#[NB]",                       ParseInfo, (void *)7);	// HPCurrent, HPMax
+	Packet.AddEvent("#*#[NB]#*#|E=#8#/#9#|#*#[NB]",                       ParseInfo, (void *)9);	// EnduranceCurrent, EnduranceMax
+	Packet.AddEvent("#*#[NB]#*#|M=#10#/#11#|#*#[NB]",                     ParseInfo, (void *)11);	// ManaCurrent, ManaMax
+	Packet.AddEvent("#*#[NB]#*#|P=#12#:#13#|#*#[NB]",                     ParseInfo, (void *)13);	// PetID, PetHPPct
+	Packet.AddEvent("#*#[NB]#*#|T=#14#:#15#|#*#[NB]",                     ParseInfo, (void *)15);	// TargetID, TargetHPPct
+	Packet.AddEvent("#*#[NB]#*#|C=#16#|#*#[NB]",                          ParseInfo, (void *)16);	// CastID
+	Packet.AddEvent("#*#[NB]#*#|Y=#17#|#*#[NB]",                          ParseInfo, (void *)17);	// State
+#if HAS_LEADERSHIP_EXPERIENCE
+	Packet.AddEvent("#*#[NB]#*#|X=#18#:#19#:#20#|#*#[NB]",                ParseInfo, (void *)20);	// Exp, AAExp, GroupLeaderExp
+#else
+	Packet.AddEvent("#*#[NB]#*#|X=#18#:#19#|#*#[NB]",                     ParseInfo, (void *)19);	// Exp, AAExp
+#endif
+	Packet.AddEvent("#*#[NB]#*#|F=#21#|#*#[NB]",                          ParseInfo, (void *)21);	// FreeBuff
+	Packet.AddEvent("#*#[NB]#*#|N=#22#|#*#[NB]",                          ParseInfo, (void *)22);	// Leader
+	Packet.AddEvent("#*#[NB]#*#|G=#30#|#*#[NB]",                          ParseInfo, (void *)30);	// Gem
+	Packet.AddEvent("#*#[NB]#*#|B=#31#|#*#[NB]",                          ParseInfo, (void *)31);	// Buff
+	Packet.AddEvent("#*#[NB]#*#|S=#32#|#*#[NB]",                          ParseInfo, (void *)32);	// Song
+	Packet.AddEvent("#*#[NB]#*#|W=#33#|#*#[NB]",                          ParseInfo, (void *)33);	// Pets
+	Packet.AddEvent("#*#[NB]#*#|D=#34#|#*#[NB]",                          ParseInfo, (void *)34);	// BDuration
+	Packet.AddEvent("#*#[NB]#*#|A=#35#:#36#:#37#|#*#[NB]",                ParseInfo, (void *)37);	// AAPoints, AAPointsSpent, AAPointsAssigned
+	Packet.AddEvent("#*#[NB]#*#|O=#38#|#*#[NB]",                          ParseInfo, (void *)38);	// CombatState
+	Packet.AddEvent("#*#[NB]#*#|U=#39#|#*#[NB]",                          ParseInfo, (void *)39);	// Note
+	Packet.AddEvent("#*#[NB]#*#|R=#40#|#*#[NB]",                          ParseInfo, (void *)40);	// Detrimental
+	Packet.AddEvent("#*#[NB]#*#|@=#89#|#*#[NB]",                          ParseInfo, (void *)89);	// Location (and X,Y,Z derived)
+	Packet.AddEvent("#*#[NB]#*#|$=#90#|#*#[NB]",                          ParseInfo, (void *)90);	// Heading
+	Packet.AddEvent("#*#[NB]#*#|<=#91#|#*#[NB]",                          ParseInfo, (void *)91);	// Extended
+	Packet.AddEvent("#*#[NB]#*#|&=#94#:#95#|#*#[NB]",                     ParseInfo, (void *)95);	// MacroState, MacroName
+	Packet.AddEvent("#*#[NB]#*#|I=#110#|#*#[NB]",                         ParseInfo, (void *)110);	// FreeInventory
+	Packet.AddEvent("#*#[NB]#*#|V=#111#|#*#[NB]",                         ParseInfo, (void *)111);	// Version
+	Packet.AddEvent("#*#[NB]#*#|K=#112#:#113#:#114#:#115#:#116#|#*#[NB]", ParseInfo, (void *)116);	// MakeCampStatus, MakeCampX, MakeCampY, MakeCampRadius, MakeCampDistance
+	Packet.AddEvent("#*#[NB]#*#|+=#117#|#*#[NB]",                         ParseInfo, (void *)117);	// LuaInfo
+	Packet.AddEvent("#*#[NB]#*#|-=#118#:#119#|#*#[NB]",                   ParseInfo, (void *)119);	// EQBC_Packets, EQBC_HeartBeat
+	Packet.AddEvent("#*#[NB]#*#|Q=#120#|#*#[NB]",                         ParseInfo, (void *)120);	// Query
+	Packet.AddEvent("#*#[NB]#*#|J=#121#:#122#|#*#[NB]",                   ParseInfo, (void *)122);	// DetrState, BeneState
+	Packet.AddEvent("#*#[NB]#*#|:=#123#|#*#[NB]",                         ParseInfo, (void *)123);	// SDuration
+	Packet.AddEvent("#*#[NB]#*#|;=#124#|#*#[NB]",                         ParseInfo, (void *)124);	// PDuration
+}
+
+void LoadBuffMap() {
+	BuffMap.clear();
+	BuffMap.emplace("Slowed",		BuffData(BT_DETRIMENTAL,	BD_SLOWED,			ST_SLOWED));
+	BuffMap.emplace("Rooted",		BuffData(BT_DETRIMENTAL,	BD_ROOTED,			ST_ROOTED));
+	BuffMap.emplace("Mesmerized",	BuffData(BT_DETRIMENTAL,	BD_MESMERIZED,		ST_MESMERIZED));
+	BuffMap.emplace("Crippled",		BuffData(BT_DETRIMENTAL,	BD_CRIPPLED,		ST_CRIPPLED));
+	BuffMap.emplace("Maloed",		BuffData(BT_DETRIMENTAL,	BD_MALOED,			ST_MALOED));
+	BuffMap.emplace("Tashed",		BuffData(BT_DETRIMENTAL,	BD_TASHED,			ST_TASHED));
+	BuffMap.emplace("Snared",		BuffData(BT_DETRIMENTAL,	BD_SNARED,			ST_SNARED));
+	BuffMap.emplace("RevDSed",		BuffData(BT_DETRIMENTAL,	BD_REVDSED,			ST_REVDSED));
+	BuffMap.emplace("Charmed",		BuffData(BT_DETRIMENTAL,	BD_CHARMED,			ST_CHARMED));
+	BuffMap.emplace("Diseased",		BuffData(BT_DETRIMENTAL,	BD_DISEASED,		ST_DISEASED));
+	BuffMap.emplace("Poisoned",		BuffData(BT_DETRIMENTAL,	BD_POISONED,		ST_POISONED));
+	BuffMap.emplace("Cursed",		BuffData(BT_DETRIMENTAL,	BD_CURSED,			ST_CURSED));
+	BuffMap.emplace("Corrupted",	BuffData(BT_DETRIMENTAL,	BD_CORRUPTED,		ST_CORRUPTED));
+	BuffMap.emplace("Blinded",		BuffData(BT_DETRIMENTAL,	BD_BLINDED,			ST_BLINDED));
+	BuffMap.emplace("CastingLevel",	BuffData(BT_DETRIMENTAL,	BD_CASTINGLEVEL,	ST_CASTINGLEVEL));
+	BuffMap.emplace("EnduDrain",	BuffData(BT_DETRIMENTAL,	BD_ENDUDRAIN,		ST_ENDUDRAIN));
+	BuffMap.emplace("Feared",		BuffData(BT_DETRIMENTAL,	BD_FEARED,			ST_FEARED));
+	BuffMap.emplace("Healing",		BuffData(BT_DETRIMENTAL,	BD_HEALING,			ST_HEALING));
+	BuffMap.emplace("Invulnerable",	BuffData(BT_DETRIMENTAL,	BD_INVULNERABLE,	ST_INVULNERABLE));
+	BuffMap.emplace("LifeDrain",	BuffData(BT_DETRIMENTAL,	BD_LIFEDRAIN,		ST_LIFEDRAIN));
+	BuffMap.emplace("ManaDrain",	BuffData(BT_DETRIMENTAL,	BD_MANADRAIN,		ST_MANADRAIN));
+	BuffMap.emplace("Resistance",	BuffData(BT_DETRIMENTAL,	BD_RESISTANCE,		ST_RESISTANCE));
+	BuffMap.emplace("Silenced",		BuffData(BT_DETRIMENTAL,	BD_SILENCED,		ST_SILENCED));
+	BuffMap.emplace("SpellCost",	BuffData(BT_DETRIMENTAL,	BD_SPELLCOST,		ST_SPELLCOST));
+	BuffMap.emplace("SpellDamage",	BuffData(BT_DETRIMENTAL,	BD_SPELLDAMAGE,		ST_SPELLDAMAGE));
+	BuffMap.emplace("SpellSlowed",	BuffData(BT_DETRIMENTAL,	BD_SPELLSLOWED,		ST_SPELLSLOWED));
+	BuffMap.emplace("Trigger",		BuffData(BT_DETRIMENTAL,	BD_TRIGGER,			ST_TRIGGER));
+	BuffMap.emplace("DSed",			BuffData(BT_BENEFICIAL,		BB_DSED,			ST_DSED));
+	BuffMap.emplace("Aego",			BuffData(BT_BENEFICIAL,		BB_AEGO,			ST_AEGO));
+	BuffMap.emplace("Skin",			BuffData(BT_BENEFICIAL,		BB_SKIN,			ST_SKIN));
+	BuffMap.emplace("Focus",		BuffData(BT_BENEFICIAL,		BB_FOCUS,			ST_FOCUS));
+	BuffMap.emplace("Regen",		BuffData(BT_BENEFICIAL,		BB_REGEN,			ST_REGEN));
+	BuffMap.emplace("Symbol",		BuffData(BT_BENEFICIAL,		BB_SYMBOL,			ST_SYMBOL));
+	BuffMap.emplace("Clarity",		BuffData(BT_BENEFICIAL,		BB_CLARITY,			ST_CLARITY));
+	BuffMap.emplace("Pred",			BuffData(BT_BENEFICIAL,		BB_PRED,			ST_PRED));
+	BuffMap.emplace("Strength",		BuffData(BT_BENEFICIAL,		BB_STRENGTH,		ST_STRENGTH));
+	BuffMap.emplace("Brells",		BuffData(BT_BENEFICIAL,		BB_BRELLS,			ST_BRELLS));
+	BuffMap.emplace("SV",			BuffData(BT_BENEFICIAL,		BB_SV,				ST_SV));
+	BuffMap.emplace("SE",			BuffData(BT_BENEFICIAL,		BB_SE,				ST_SE));
+	BuffMap.emplace("HybridHP",		BuffData(BT_BENEFICIAL,		BB_HYBRIDHP,		ST_HYBRIDHP));
+	BuffMap.emplace("Growth",		BuffData(BT_BENEFICIAL,		BB_GROWTH,			ST_GROWTH));
+	BuffMap.emplace("Shining",		BuffData(BT_BENEFICIAL,		BB_SHINING,			ST_SHINING));
+	BuffMap.emplace("Hasted",		BuffData(BT_BENEFICIAL,		BB_HASTED,			ST_HASTED));
+}
+
+PLUGIN_API void InitializePlugin() {
+	if (DEBUGGING) {
+		DebugSpewAlways("%s->InitializePlugin()", PLUGIN_NAME);
+	}
+	NetMap.clear();
+	LoadEvents();
+	LoadBuffMap();
 	ZeroMemory(sTimers, sizeof(sTimers));
 	ZeroMemory(sBuffer, sizeof(sBuffer));
 	ZeroMemory(wBuffer, sizeof(wBuffer));
@@ -1878,14 +3609,477 @@ PLUGIN_API VOID InitializePlugin(VOID) {
 	AddMQ2Data("NetBots", dataNetBots);
 	AddCommand("/netbots", Command);
 	AddCommand("/netnote", CommandNote);
+	AddXMLFile("MQUI_NetBotsWnd.xml");
 }
 
-PLUGIN_API VOID ShutdownPlugin(VOID) {
-#if    DEBUGGING>0
-	DebugSpewAlways("%s->ShutdownPlugin()", PLUGIN_NAME);
-#endif DEBUGGING
+PLUGIN_API void ShutdownPlugin() {
+	if (DEBUGGING) {
+		DebugSpewAlways("%s->ShutdownPlugin()", PLUGIN_NAME);
+	}
 	RemoveCommand("/netbots");
 	RemoveCommand("/netnote");
 	RemoveMQ2Data("NetBots");
 	delete pNetBotsType;
+}
+
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
+//
+//  Window Info and Class - Uses custom XML Window - MQUI_NetBotsWnd.xml
+//
+//=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=//
+
+enum eTextColors {
+	TEXT_WHITE 			= 0xFFFFFFFF,
+	TEXT_GREEN 			= 0xFF00FF00,
+	TEXT_YELLOW			= 0xFFFFFF00,
+	TEXT_RED 			= 0xFFFF0000,
+	TEXT_SKY_BLUE		= 0xFF87CEEB,
+	TEXT_SALMON			= 0xFFFA8072,
+	TEXT_DODGER_BLUE	= 0xFF1E90FF
+};
+
+enum eListBoxColumns {
+	LBC_NAME,
+	LBC_LEVEL,
+	LBC_NULL_SPACER,
+	LBC_CLASS,
+	LBC_HP,
+	LBC_MANA,
+	LBC_ENDUR,
+	LBC_DISTANCE,
+	LBC_STATE,
+	LBC_INVIS,
+	LBC_ACTION,
+	LBC_TARGET,
+	LBCSIZE
+};
+
+enum eOldListBoxColumns {
+	OLBC_MANA,
+	OLBC_ENDUR,
+	OLBC_HP,
+	OLBC_DISTANCE,
+	OLBC_STATE,
+	OLBC_NAME,
+	OLBC_TARGET,
+	OLBC_ACTION,
+	OLBCSIZE
+};
+
+class CMyWnd : public CCustomWnd {
+public:
+	CListWnd* List = nullptr;
+	int ErrorLoading = 0;
+	int wClick = 0;
+
+	CMyWnd() : CCustomWnd(WindowID) {
+		List = (CListWnd*)GetChildItem(ScreenID);
+		if (!List) {
+			ErrorLoading = 1;
+			WriteChatf("MQ2NetBots::Could not find %s. Make sure your MQUI_NetBotsWnd.xml is up to date.", ScreenID);
+			return;
+		}
+	}
+
+	void ShowWin() {
+		Show(true);
+		SetVisible(true);
+	}
+	
+	void HideWin() {
+		Show(false);
+		SetVisible(false);
+	}
+
+	virtual int WndNotification(CXWnd *pWnd, unsigned int Message, void *unknown) override {
+		if (pWnd == nullptr) {
+			if (Message == XWM_CLOSE) {
+				CreateMyWindow();
+				ShowWin();
+				return 0;
+			}
+		}
+		if (Message == XWM_LCLICK) {
+			wClick = NetLClick;
+		} else if (Message == XWM_RCLICK) {
+			wClick = NetRClick;
+		}
+		return CSidlScreenWnd::WndNotification(pWnd, Message, unknown);
+	};
+
+};
+
+CMyWnd *MyWnd=0;
+
+void CreateMyWindow() {
+	if (NetUseNewWindow) {
+		strcpy_s(WindowID, "NBClientWnd");
+		strcpy_s(ScreenID, "Client_List");
+	} else {
+		strcpy_s(WindowID, "NetBotsWnd");
+		strcpy_s(ScreenID, "NBW_List");
+	}
+	if (IsScreenPieceLoaded(WindowID)) {
+		MyWnd = new CMyWnd;
+		if (MyWnd && MyWnd->ErrorLoading) {
+			delete MyWnd;
+			MyWnd = 0;
+		}
+		if (MyWnd) {
+			ReadWindowINI(MyWnd);
+			WriteWindowINI(MyWnd);
+			if (NetUseNewWindow) {
+				MyWnd->List->SetColumnJustification(LBC_LEVEL, 2);  // Right-justify Level
+			}
+		}
+	} else {
+		WriteChatf("MQ2NetBots::Could not find %s. Make sure your MQUI_NetBotsWnd.xml is up to date.", WindowID);
+	}
+}
+
+void DestroyMyWindow() {
+	if (MyWnd) {
+		WriteWindowINI(MyWnd);
+		MyWnd->List->DeleteAll();
+		delete MyWnd;
+		MyWnd = 0;
+	}
+}
+
+void ShowMyWindow() {
+	if (gGameState != GAMESTATE_INGAME || !pLocalPlayer) {
+		return;
+	}
+	if (!MyWnd) {
+		CreateMyWindow();
+		if (!MyWnd) {
+			return;
+		}
+	}
+	MyWnd->ShowWin();
+	WindowUpdate();
+}
+
+void HideMyWindow() {
+	if (!MyWnd) {
+		return;
+	}
+	MyWnd->HideWin();
+}
+
+void ReadWindowINI(CSidlScreenWnd* pWindow) {
+	pWindow->SetEscapable(0);
+	pWindow->SetLocation(
+		{
+			GetPrivateProfileInt(PlayerSectionName, "ChatLeft",   175, GlobalINIFileName),
+			GetPrivateProfileInt(PlayerSectionName, "ChatTop",    350, GlobalINIFileName),
+			GetPrivateProfileInt(PlayerSectionName, "ChatRight",  675, GlobalINIFileName),
+			GetPrivateProfileInt(PlayerSectionName, "ChatBottom", 625, GlobalINIFileName)
+		}
+	);
+
+	pWindow->SetLocked      ((GetPrivateProfileInt(PlayerSectionName, "Locked",         0, GlobalINIFileName) ? true : false));
+	pWindow->SetFades       ((GetPrivateProfileInt(PlayerSectionName, "Fades",          1, GlobalINIFileName) ? true : false));
+	pWindow->SetFadeDelay    (GetPrivateProfileInt(PlayerSectionName, "Delay",       2000, GlobalINIFileName));
+	pWindow->SetFadeDuration (GetPrivateProfileInt(PlayerSectionName, "Duration",     500, GlobalINIFileName));
+	pWindow->SetAlpha        (GetPrivateProfileInt(PlayerSectionName, "Alpha",        255, GlobalINIFileName));
+	pWindow->SetFadeToAlpha  (GetPrivateProfileInt(PlayerSectionName, "FadeToAlpha",  255, GlobalINIFileName));
+	pWindow->SetBGType       (GetPrivateProfileInt(PlayerSectionName, "BGType",         1, GlobalINIFileName));
+	
+	ARGBCOLOR col = { 0 };
+	col.A = GetPrivateProfileInt(PlayerSectionName, "BGTint.alpha", 255, GlobalINIFileName);
+	col.R = GetPrivateProfileInt(PlayerSectionName, "BGTint.red",     0, GlobalINIFileName);
+	col.G = GetPrivateProfileInt(PlayerSectionName, "BGTint.green",   0, GlobalINIFileName);
+	col.B = GetPrivateProfileInt(PlayerSectionName, "BGTint.blue",    0, GlobalINIFileName);
+	pWindow->SetBGColor(col.ARGB);
+}
+
+void WriteWindowINI(CSidlScreenWnd* pWindow) {
+	char szTemp[MAX_STRING] = { 0 };
+	if (pWindow->IsMinimized())	{
+		WritePrivateProfileInt(PlayerSectionName, "ChatTop",    pWindow->GetOldLocation().top,    GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatBottom", pWindow->GetOldLocation().bottom, GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatLeft",   pWindow->GetOldLocation().left,   GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatRight",  pWindow->GetOldLocation().right,  GlobalINIFileName);
+	} else {
+		WritePrivateProfileInt(PlayerSectionName, "ChatTop",    pWindow->GetLocation().top,    GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatBottom", pWindow->GetLocation().bottom, GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatLeft",   pWindow->GetLocation().left,   GlobalINIFileName);
+		WritePrivateProfileInt(PlayerSectionName, "ChatRight",  pWindow->GetLocation().right,  GlobalINIFileName);
+	}
+	WritePrivateProfileInt(PlayerSectionName, "Locked",      pWindow->IsLocked(),        GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "Fades",       pWindow->GetFades(),        GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "Delay",       pWindow->GetFadeDelay(),    GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "Duration",    pWindow->GetFadeDuration(), GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "Alpha",       pWindow->GetAlpha(),        GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "FadeToAlpha", pWindow->GetFadeToAlpha(),  GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "BGType",      pWindow->GetBGType(),       GlobalINIFileName);
+	ARGBCOLOR col = { 0 };
+	col.ARGB = pWindow->GetBGColor();
+	WritePrivateProfileInt(PlayerSectionName, "BGTint.alpha", col.A, GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "BGTint.red",   col.R, GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "BGTint.green", col.G, GlobalINIFileName);
+	WritePrivateProfileInt(PlayerSectionName, "BGTint.blue",  col.B, GlobalINIFileName);
+}
+	
+void WndListPrintf(CListWnd* pWnd, int R, int C, int Color, const char* zFormat, ...) {
+	va_list vaList;
+	va_start(vaList, zFormat);
+	char szTemp[MAX_STRING];
+	vsprintf_s(szTemp, MAX_STRING, zFormat, vaList);
+	if (pWnd) {
+		pWnd->SetItemText(R, C, szTemp);
+		pWnd->SetItemColor(R, C, Color);
+	}
+}
+
+void WndListPrintPerc(CListWnd* pWnd, int R, int C, int Cur, int Max) {
+	if (Max < 1) {
+		WndListPrintf(pWnd, R, C, TEXT_WHITE, "");
+		return;
+	}
+	int cColor = 0;
+	float v = (float)100.0 * Cur / Max;
+	if (v > 70) {
+		cColor = TEXT_GREEN;
+	} else if (v > 40) {
+		cColor = TEXT_YELLOW;
+	} else {
+		cColor = TEXT_RED;
+	}
+	WndListPrintf(pWnd, R, C, cColor, "%3.0f", v);
+}
+
+void WndListPrintDist(CListWnd* pWnd, int R, int C, int Distance) {
+	int cColor = 0;
+	if (Distance < 30) {
+		cColor = TEXT_GREEN;
+	} else if (Distance < 65) {
+		cColor = TEXT_DODGER_BLUE;
+	} else if (Distance < 100) {
+		cColor = TEXT_YELLOW;
+	} else {
+		cColor = TEXT_SALMON;
+	}
+	WndListPrintf(pWnd, R, C, cColor, "%d", (Distance >= 9999 ? 9999 : Distance));
+}
+
+void WindowSetHeight(CSidlScreenWnd* pWindow, int height) {
+	if (height != pWindow->GetLocation().bottom - pWindow->GetLocation().top) {
+		int width  = pWindow->GetLocation().right - pWindow->GetLocation().left;
+		((CXWnd*)(pWindow))->Resize(width, height);
+	}
+}
+
+void WindowUpdate() {
+	static int MaxLines = 0;
+	char szOutput[MAX_STRING] = { 0 };
+	if (!MyWnd || !MyWnd->List) {
+		return;
+	}
+	ShowTime = MQGetTickCount64() + 100;
+	if (MyWnd->IsVisible()) {
+		strcpy_s(szOutput, NetWindowTitle);
+		ParseMacroData(szOutput, MAX_STRING);
+		MyWnd->SetWindowText(szOutput);
+		int Distance = 0;
+		bool inZone = false;
+		bool isSelf = false;
+		int cColor = 0;
+		int iCount = MyWnd->List->GetItemCount();
+		int CurSel = MyWnd->List->GetCurSel();
+		int R = 0;
+		int C = 0;
+		for (auto& [_, botInfo] : NetMap) {
+			if (botInfo->SpawnID == 0) {
+				continue;
+			}
+			if (R >= iCount) {
+				MyWnd->List->AddString("", TEXT_WHITE, 0, 0);
+//				WriteChatf("Added a row. Now: %d", MyWnd->List->GetItemCount());
+			}
+			if (_stricmp(pLocalPC->Name, botInfo->Name) == 0) {
+				isSelf = true;
+				inZone = true;
+				Distance = 0;
+			} else {
+				isSelf = false;
+				if (pLocalPC && pLocalPC->zoneId == botInfo->ZoneID && pLocalPC->instance == botInfo->InstanceID) {
+					inZone = true;
+					Distance = static_cast<int>(std::round(Get3DDistance(pLocalPlayer->X, pLocalPlayer->Y, pLocalPlayer->Z, botInfo->X, botInfo->Y, botInfo->Z)));
+				} else {
+					inZone = false;
+					Distance = 0;
+				}
+			}
+			
+			// Name
+			if (!inZone) {
+				cColor = TEXT_SKY_BLUE;
+			} else if (Distance > 100) {
+				cColor = TEXT_SALMON;
+			} else {
+				cColor = TEXT_WHITE;
+			}
+			WndListPrintf(MyWnd->List, R, (NetUseNewWindow ? LBC_NAME : OLBC_NAME), cColor, botInfo->Name);
+			
+			if (NetUseNewWindow) {
+				// Level
+				WndListPrintf(MyWnd->List, R, LBC_LEVEL, TEXT_WHITE, "%3d", botInfo->Level);
+				// Class
+				WndListPrintf(MyWnd->List, R, LBC_CLASS, TEXT_WHITE, pEverQuest->GetClassThreeLetterCode(botInfo->ClassID));
+			}
+
+			// HP Percent
+			WndListPrintPerc(MyWnd->List, R, (NetUseNewWindow ? LBC_HP : OLBC_HP), botInfo->HPCurrent, botInfo->HPMax);
+			// Mana Percent
+			WndListPrintPerc(MyWnd->List, R, (NetUseNewWindow ? LBC_MANA : OLBC_MANA), botInfo->ManaCurrent, botInfo->ManaMax);
+			// Endurance Percent
+			WndListPrintPerc(MyWnd->List, R, (NetUseNewWindow ? LBC_ENDUR : OLBC_ENDUR), botInfo->EnduranceCurrent, botInfo->EnduranceMax);
+
+			// Distance
+			C = (NetUseNewWindow ? LBC_DISTANCE : OLBC_DISTANCE);
+			if (!inZone) {
+				WndListPrintf(MyWnd->List, R, C, TEXT_SKY_BLUE, " ----");
+			} else if (isSelf) {
+				WndListPrintf(MyWnd->List, R, C, TEXT_WHITE, "");
+			} else {
+				WndListPrintDist(MyWnd->List, R, C, Distance);
+			}
+
+			// State
+			sprintf_s(szOutput, " ");
+			cColor = TEXT_WHITE;
+			if (botInfo->State & STATE_DEAD) {
+				szOutput[0] = 'x';
+				cColor = TEXT_RED;
+			} else if (botInfo->State & STATE_STUN) {
+				szOutput[0] = '-';
+				cColor = TEXT_RED;
+			} else if (!NetUseNewWindow && (botInfo->State & STATE_INVIS) && (botInfo->State & STATE_ITU)) {
+				szOutput[0] = 'B';
+			} else if (!NetUseNewWindow && (botInfo->State & STATE_INVIS)) {
+				szOutput[0] = 'I';
+			} else if (!NetUseNewWindow && (botInfo->State & STATE_ITU)) {
+				szOutput[0] = 'U';
+			} else if (botInfo->State & STATE_SIT) {
+				szOutput[0] = 'S';
+			} else if (botInfo->State & STATE_HAVEAGGRO) {
+				szOutput[0] = 'T';
+			} else if (botInfo->State & STATE_WANTAGGRO) {
+				szOutput[0] = 'A';
+			} else if (botInfo->State & STATE_MOUNT) {
+				szOutput[0] = 'M';
+			}
+			WndListPrintf(MyWnd->List, R, (NetUseNewWindow ? LBC_STATE : OLBC_STATE), cColor, szOutput);
+
+			if (NetUseNewWindow) {
+				// Invis
+				if ((botInfo->State & STATE_INVIS) && (botInfo->State & STATE_ITU)) {
+					WndListPrintf(MyWnd->List, R, LBC_INVIS, TEXT_DODGER_BLUE, "BOTH");
+				} else if (botInfo->State & STATE_INVIS) {
+					WndListPrintf(MyWnd->List, R, LBC_INVIS, TEXT_GREEN, "INV");
+				} else if (botInfo->State & STATE_ITU) {
+					WndListPrintf(MyWnd->List, R, LBC_INVIS, TEXT_YELLOW, "IVU");
+				} else {
+					WndListPrintf(MyWnd->List, R, LBC_INVIS, TEXT_WHITE, "");
+				}
+			}
+
+			// Action
+			C = (NetUseNewWindow ? LBC_ACTION : OLBC_ACTION);
+			if (botInfo->CastID) {
+				WndListPrintf(MyWnd->List, R, C, TEXT_WHITE, GetSpellByID(botInfo->CastID)->Name);
+			} else if (botInfo->State & STATE_ATTACK) {
+				WndListPrintf(MyWnd->List, R, C, TEXT_WHITE, "Melee");
+			} else if (botInfo->State & STATE_RANGED) {
+				WndListPrintf(MyWnd->List, R, C, TEXT_WHITE, "Ranged");
+			} else {
+				WndListPrintf(MyWnd->List, R, C, TEXT_WHITE, "");
+			}
+
+			// Target
+			char* p = szOutput;
+			szOutput[0] = 0;
+			cColor = TEXT_WHITE;
+			if (inZone && botInfo->TargetID) {
+				auto pBotTarget = GetSpawnByID(botInfo->TargetID);
+				if (!pBotTarget) {
+					sprintf_s(szOutput, "id %d", botInfo->TargetID);
+				} else {
+					if (GetSpawnType(pBotTarget)==NPC) {
+						if (NetCleanNames) {
+							sprintf_s(szOutput, "%s", pBotTarget->DisplayedName);
+						} else {
+							sprintf_s(szOutput, "%s", pBotTarget->Name);
+						}
+						if (NetConColors) {
+							cColor = ConColorToARGB(ConColor(pBotTarget));
+						}
+					} else {
+						sprintf_s(szOutput, "%s", pBotTarget->DisplayedName);
+					}
+				}
+				if (NetRightMost > 0) {
+					int zlen = static_cast<int>(strlen(szOutput));
+					if (zlen > NetRightMost) {
+						p = &szOutput[zlen - NetRightMost];
+					}
+				}
+			}
+			WndListPrintf(MyWnd->List, R, (NetUseNewWindow ? LBC_TARGET : OLBC_TARGET), cColor, p);
+
+			// If we have selected someone from the list, take action
+			if (CurSel == R) {
+				switch (MyWnd->wClick) {
+					case CA_NO_ACTION:
+						break;
+					case CA_BRING_TO_FOREGROUND:
+						if (_stricmp(pLocalPC->Name, botInfo->Name) != 0) {
+							sprintf_s(szOutput, "/bct %s //foreground", botInfo->Name);
+							EzCommand(szOutput);
+						}
+						break;
+					case CA_TARGET_PLAYER:
+						if (inZone && botInfo->SpawnID) {
+							sprintf_s(szOutput, "/mqtarget id %d", botInfo->SpawnID);
+							EzCommand(szOutput);
+						}
+						break;
+					case CA_TARGET_PLAYER_TARGET:
+						if (inZone && botInfo->TargetID) {
+							sprintf_s(szOutput, "/mqtarget id %d", botInfo->TargetID);
+							EzCommand(szOutput);
+						}
+						break;
+					default:
+						break;
+				}
+			}
+			R++;
+		}
+		// If we lost clients, clear the old data. Leave the rows, we will adjust height to hide the empty ones.
+		// No need to constantly delete and re-add. Especially since the clients disappear/reappear when they zone.
+		int cSize = (NetUseNewWindow ? LBCSIZE : OLBCSIZE);
+		for (int i = R; i < MaxLines; i++) {
+			for (int C = 0; C < cSize; C++) {
+				WndListPrintf(MyWnd->List, i, C, TEXT_WHITE, "");
+			}
+		}
+		WindowSetHeight(MyWnd, 50 + 14 * R);
+		MaxLines = R;
+	}
+	MyWnd->List->SetCurSel(-1);
+}
+
+PLUGIN_API void OnCleanUI() {
+	DestroyMyWindow();
+}
+
+PLUGIN_API void OnReloadUI() {
+	if (gGameState == GAMESTATE_INGAME && pLocalPlayer) {
+		if (NetShow) {
+			ShowMyWindow();
+		}
+	}
 }

--- a/README.md
+++ b/README.md
@@ -1,1 +1,296 @@
-# MQ2NetBots
+# Description
+MQ2NetBots provides linked MQ2EQBC clients a method of sharing status information and statistics. It also adds a new Top-Level Object ${NetBots}.
+
+# Commands
+/netbots on/off - Toggles NetBots on or off.<BR>
+/netbots grab=on/off - Toggles receiving status updates from other NetBots clients connected to EQBCS.<BR>
+/netbots send=on/off - Toggles NetBots clients sending of status updates to EQBCS on or off.<BR>
+/netbots extended=0/1/2/3 - Sets whether client will send extended status updates to EQBCS. 0=None,1=Gems + Buff Durations,2=Add Short Durations,3=Add Pet Buff Durations.<BR>
+/netbots simple=on/off - Toggles simple spell name searching (which allows any substring to match) on or off.<BR>
+/netbots show - Sets showing the NetBots window to on.<BR>
+/netbots hide - Sets showing the NetBots window to off.<BR>
+/netbots switch - Will switch between old and new NetBots window format.<BR>
+/netbots concolors=on/off - Toggles use of ConColors for Target names in the NetBots window on or off.<BR>
+/netbots cleannames=on/off - Toggles use of CleanNames for Target names in the NetBots window on or off.<BR>
+/netbots lclick=0/1/2/3 - Set the mouse left-click action on a data row in the NetBots window. 0=None,1=Bring to Foreground,2=Target Player,3=Target Player Target.<BR>
+/netbots rclick=0/1/2/3 - Set the mouse right-click action on a data row in the NetBots window. 0=None,1=Bring to Foreground,2=Target Player,3=Target Player Target.<BR>
+/netbots load - Will re-load all settings using the .ini file.<BR>
+/netnote [note] - Sets the NetBots Note field of the client.<BR>
+
+
+# INI Examples
+## server_Character.INI
+
+[MQ2NetBots]<BR>
+Stat=1<BR>
+Grab=1<BR>
+Send=1<BR>
+Extended=0<BR>
+UseSimpleSearch=0<BR>
+Show=1<BR>
+LClick=2<BR>
+RClick=3<BR>
+ConColors=1<BR>
+CleanNames=1<BR>
+
+
+## MQ2NetBots.INI
+
+[Settings]<BR>
+Query=<BR>
+WindowTitle=MQ2NetBots (${NetBots.Counts})<BR>
+[server.Character]<BR>
+ChatTop=742<BR>
+ChatBottom=820<BR>
+ChatLeft=468<BR>
+ChatRight=974<BR>
+Locked=0<BR>
+Fades=1<BR>
+Delay=2000<BR>
+Duration=500<BR>
+Alpha=255<BR>
+FadeToAlpha=154<BR>
+BGType=2<BR>
+BGTint.alpha=255<BR>
+BGTint.red=0<BR>
+BGTint.green=0<BR>
+BGTint.blue=0<BR>
+
+
+
+# INI Settings Definition
+## server_Character.INI
+
+All settings are in the [MQ2NetBots] section.
+
+Stat - This enables (set to 1) or disables (set to 0) MQ2NetBots send and receive data and processing. Setting this to 0 effectively disables the plugin. Use the /netbots on or /netbots off commands toggle this in game.<BR><BR>
+Grab - Whether to listen for NetBots data. If this particular character needs to send information, but doesn't care about information from other clients, you can set this to 0 so it doesn't process incoming data. Set to 1 to process the data. Use the /netbots grab=on or /netbots grab=off commands toggle this in game.<BR><BR>
+Send - Whether to send NetBots data to other clients via eqbc. If this character needs to receive other netbots client info, but doesn't need to send it, you can set this to 0 to disable it. Set to 1 to enable. Use the /netbots send=on or /netbots send=off commands toggle this in game.<BR><BR>
+Extended - Whether to send additional detailed data to other netbots clients via EQBC. This includes Gems and Buff/Song Durations. 0=None, 1=Gems+Buff Durations, 2=1+Add Short Durations, 3=2+Add Pet Buff Durations. Use the /netbots ext command to chamge this in game.<BR><BR>
+SendEQBCData - Whether to send additional information related to EQBC Packets/Heartbeat. 0=off, 1=on. Recommend off to cut down on unecessary EQBC traffic.<BR><BR>
+UseSimpleSearch - Whether to allow simple searching when providing Spell Names. Simple will match any substring of the spell to your search term. Use the /netbots simple=on or /netbots simple=off commands toggle this in game.<BR><BR>
+Show - Whether to show the NetBots client information window in game. Set to 0 to disable, 1 to enable. Use the /netbots show or /netbots hide commands toggle this in game.<BR><BR>
+UseNewWindow - Whether to use the new client information window format or the old. 0=Old, 1=New. Use the /netbots switch command to toggle this in game.<BR><BR>
+ConColors - Whether to use EQ ConColors when displaying the Target names in the NetBots window. Set to 0 to disable, 1 to enable. Use the /netbots concolors=on or /netbots concolors=off commands toggle this in game.<BR><BR>
+CleanNames - Whether to use Cleaned Names EQ displaying the Target names in the NetBots window. Set to 0 to disable, 1 to enable. Use the /netbots cleannames=on or /netbots cleannames=off commands toggle this in game.<BR><BR>
+LClick - Set the mouse left-click action on a data row in the NetBots window. 0=No Action, 1=Bring the selected client to the foreground, 2=Target the selected client, 3=Target the selected client's target. Use the /netbots lclick command to change this in game.<BR><BR>
+RClick - Set the mouse right-click action on a data row in the NetBots window. 0=No Action, 1=Bring the selected client to the foreground, 2=Target the selected client, 3=Target the selected client's target. Use the /netbots rclick command to change this in game.<BR><BR>
+TargetRightMost - Can be used to truncate the target in the NetBots window to show only the rightmost # of characters. The old window format had this hardcoded at 12 (if you want to replicate its functionality).<BR><BR>
+
+## MQ2NetBots.INI
+
+[Settings] section
+
+WindowTitle - The Title used for the im-game NetBots UI window (Show=1).<BR><BR>
+Query - An additional Macro-type query that will be executed on each client with results accessed by ${NetBots[Name].Query}. Keep this reasonable, the more data sent to clients the easier it is to overwhelm EQBC.<BR>
+
+	Example INI entry:
+	Query=${Bot.DoPulls},${Bot.LootRadius},${Pet.Name}
+	Example query:  ${NetBots[Charname].Query.Arg[1,,]}
+	Example Query data if Bot.DoPulls is true and Bot.LootRadius is 20 on Charname:  TRUE,20
+	Output from above example:  TRUE
+
+[server.Character] section
+
+This section contains NetBots UI window related settings (Show=1).
+
+
+# Macro Data
+
+Examples
+
+/echo ${NetBots[MY\_TOON].CurrentHPs}<BR>
+/echo ${NetBots[MY\_TOON].Buff[4]}
+
+# Top-Level Object
+
+${NetBots} Returns information about your client.<BR>
+${NetBots[Name]} Returns information about the connected toon Name.
+
+# Data Types - NetBots
+
+${NetBots.Enable} :Bool Returns TRUE/FALSE based on plugin status.<BR>
+${NetBots.Listen} :Bool Returns TRUE/FALSE based on grab parameter status.<BR>
+${NetBots.Output} :Bool Returns TRUE/FALSE based on send parameter status.<BR>
+${NetBots.Counts} :Int Returns count of currently broadcasting NetBots clients connected to EQBCS.<BR>
+${NetBots.Client} :String Returns list of currently broadcasting NetBots clients connected to EQBCS.<BR>
+
+
+# Data Types - NetBots Clients
+
+${NetBots[Name].Name} :String Name of Name.<BR>
+${NetBots[Name].Zone} :Int Zone ID of Name.<BR>
+${NetBots[Name].Instance} :Int Instance ID of Name.<BR>
+${NetBots[Name].ID} :Int Spawn ID of Name.<BR>
+${NetBots[Name].Class} :Class Class of Name.<BR>
+${NetBots[Name].Level} :Int Level of Name.<BR>
+${NetBots[Name].PctExp} :Float Percent Experience of Name.<BR>
+${NetBots[Name].PctAAExp} :Float Percent AA Experience of Name.<BR>
+${NetBots[Name].PctGroupLeaderExp} :Float Percent Group Leader Experience of Name. EMU servers only.<BR>
+${NetBots[Name].CurrentHPs} :Int Current Hitpoints of Name.<BR>
+${NetBots[Name].MaxHPs} :Int Total Hitpoints of Name<BR>
+${NetBots[Name].PctHPs} :Int Current Hitpoints percentage of Name.<BR>
+${NetBots[Name].CurrentEndurance} :Int Current Endurace of Name.<BR>
+${NetBots[Name].MaxEndurance} :Int Total Endurance of Name.<BR>
+${NetBots[Name].PctEndurace} :Int Current Endurance percentage of Name.<BR>
+${NetBots[Name].CurrentMana} :Int Current Mana of Name.<BR>
+${NetBots[Name].MaxMana} :Int Total Mana of Name.<BR>
+${NetBots[Name].PctMana} :Int Current Mana percentage of Name.<BR>
+${NetBots[Name].PetID} :Int Spawn ID of Name's pet.<BR>
+${NetBots[Name].PetHP} :Int Hitpoints Percentage of Name's pet. (Same as PetPctHPs)<BR>
+${NetBots[Name].PetPctHPs} :Int Hitpoints Percentage of Name's pet. (Same as PetHP)<BR>
+${NetBots[Name].TargetID} :Int Spawn ID of Name's target.<BR>
+${NetBots[Name].TargetHP} :Int Hitpoints Percentage of Name's target. (Same as TargetPctHPs)<BR>
+${NetBots[Name].TargetPctHPs} :Int Hitpoints Percentage of Name's target. (Same as TargetHP)<BR>
+${NetBots[Name].Casting} :Spell Spell (if any) Name is currently casting.<BR>
+${NetBots[Name].State} :String State of Name (STUN HOVER MOUNT STAND SIT DUCK BIND FEIGN DEAD UNKNOWN).<BR>
+${NetBots[Name].Attacking} :Bool Is Name Attacking?<BR>
+${NetBots[Name].AFK} :Bool Is Name AFK?<BR>
+${NetBots[Name].Binding} :Bool Is Name kneeling?<BR>
+${NetBots[Name].Ducking} :Bool Is Name ducking?<BR>
+${NetBots[Name].Feigning} :Bool Is Name feigning?<BR>
+${NetBots[Name].Grouped} :Bool Is Name in a group?<BR>
+${NetBots[Name].InGroup} :Bool Is Name in your group?<BR>
+${NetBots[Name].Invis} :Bool Is Name invis (normal)?<BR>
+${NetBots[Name].InvisToUndead} :Bool Is Name invis to undead?<BR>
+${NetBots[Name].Levitating} :Bool Is Name levitating?<BR>
+${NetBots[Name].LFG} :Bool Is Name LFG?<BR>
+${NetBots[Name].Mounted} :Bool Is Name on a mount?<BR>
+${NetBots[Name].Moving} :Bool Is Name moving?<BR>
+${NetBots[Name].Raid} :Bool Is Name in a raid?<BR>
+${NetBots[Name].Sitting} :Bool Is Name sitting?<BR>
+${NetBots[Name].Standing} :Bool Is Name standing?<BR>
+${NetBots[Name].Stunned} :Bool Is Name stunned?<BR>
+${NetBots[Name].Dead} :Bool Is Name dead?<BR>
+${NetBots[Name].Hover} :Bool Is Name in hover mode?<BR>
+${NetBots[Name].AutoFire} :Bool Is Name ranged auto-firing?<BR>
+${NetBots[Name].HaveAggro} :Bool Does Name have aggro?<BR>
+${NetBots[Name].WantAggro} :Bool Does Name want aggro? (MQ2Melee AggroMode=1)<BR>
+${NetBots[Name].PetAffinity} :Bool Does Name have Pet Affinity (or equivalent) AA for pet receiving group buffs?<BR>
+${NetBots[Name].Extended} :Bool Is Name sending extended information in MQ2NetBots (Extended=1)?<BR>
+${NetBots[Name].FreeBuffSlots} :Int Total free buff slots Name has.<BR>
+${NetBots[Name].InZone} :Bool Is Name in the same zone as you?<BR>
+${NetBots[Name].Leader} :String The name of Name's group leader. (Same as GroupLeader)<BR>
+${NetBots[Name].GroupLeader} :String The name of Name's group leader. (Same as Leader)<BR>
+${NetBots[Name].Note} :String The Note string set in Name's MQ2NetBots Note field.<BR>
+${NetBots[Name].Location} :String The Y,X,Z location of Name.<BR>
+${NetBots[Name].X} :Float The X location of Name.<BR>
+${NetBots[Name].Y} :Float The Y location of Name.<BR>
+${NetBots[Name].Z} :Float The Z location of Name.<BR>
+${NetBots[Name].Distance} :Float The distance you are away from Name.<BR>
+${NetBots[Name].FreeInventory} :Int The number of free inventory slots for Name.<BR>
+${NetBots[Name].FreeInventory[#]} :Int The number of Name's free inventory slots of at least size [#] for Name.<BR>
+${NetBots[Name].Heading} :String The Heading of Name.<BR>
+${NetBots[Name].Updated} :Int Time since last NetBots update from Name.<BR>
+${NetBots[Name].Version} :Float The version number the MQ2NetBots that Name is running.<BR>
+${NetBots[Name].Gem} :String String of spell IDs Name has memorized. Requires Extended=1 in Name's ini.<BR>
+${NetBots[Name].Gem[#]}} :Spell Spell Name has memorized in Gem[#]. Requires Extended=1 in Name's ini.<BR>
+${NetBots[Name].Gem[spellname]}} :Spell pSpellType of the spell Name has if he currently has [spellname] memorized. Can be full/partial. Requires Extended=1 in Name's ini.<BR>
+${NetBots[Name].Buff} :String String of spell IDs of all buffs Name currently has.<BR>
+${NetBots[Name].Buff[#]} :Spell Spell Name currently has in buff slot [#].<BR>
+${NetBots[Name].Buff[spellname]} :Spell pSpellType of the buff Name has if he has [spellname] buff. Can be full/partial.<BR>
+${NetBots[Name].Duration} :String String of the remaining durations of all buffs Name has. Requires Extended=1 in Name's ini. (Same as BuffDuration)<BR>
+${NetBots[Name].Duration[#]} :Ticks Duration of the buff on Name in slot [#]. Requires Extended=1 in Name's ini. (Same as BuffDuration)<BR>
+${NetBots[Name].Duration[spellname]} :Ticks Duration of the buff on Name if he has [spellname] buff. Requires Extended=1 in Name's ini. (Same as BuffDuration)<BR>
+${NetBots[Name].BuffDuration} :String String of the remaining durations of all buffs Name has. Requires Extended=1 in Name's ini. (Same as Duration)<BR>
+${NetBots[Name].BuffDuration[#]} :Ticks Duration of the buff on Name in slot [#]. Requires Extended=1 in Name's ini. (Same as Duration)<BR>
+${NetBots[Name].BuffDuration[spellname]} :Ticks Duration of the buff on Name if he has [spellname] buff. Requires Extended=1 (or greater) in Name's ini. (Same as Duration)<BR>
+${NetBots[Name].ShortBuff} :String String of spell IDs of all short duration buffs Name currently has.<BR>
+${NetBots[Name].ShortBuff[#]} :Spell Spell Name currently has in short duration buff slot [#].<BR>
+${NetBots[Name].ShortBuff[spellname]} :Spell pSpellType of the short duration buff Name has if he has [spellname] short duration buff. Can be full/partial.<BR>
+${NetBots[Name].ShortDuration} :String String of the remaining durations of all short duration buffs Name has. Requires Extended=2 (or greater) in Name's ini.<BR>
+${NetBots[Name].ShortDuration[#]} :Ticks Duration of the buff on Name in short duration slot [#]. Requires Extended=2 (or greater) in Name's ini.<BR>
+${NetBots[Name].ShortDuration[spellname]} :Ticks Duration of the buff on Name if he has [spellname] short duration buff. Requires Extended=1 in Name's ini.<BR>
+${NetBots[Name].PetBuff} :String String of spell IDs of all buffs on Name's pet.<BR>
+${NetBots[Name].PetBuff[#]} :Spell Name of the buff in slot [#] of Name's pet.<BR>
+${NetBots[Name].PetBuff[spellname]} :Spell pSpellType of the buff Name's pet if it has [spellname] buff. Can be full/partial.<BR>
+${NetBots[Name].PetDuration} :String String of the remaining durations of all buffs on Name's pet. Requires Extended=3 in Name's ini.<BR>
+${NetBots[Name].PetDuration[#]} :Ticks Duration of the buff on Name's pet in slot [#]. Requires Extended=3 in Name's ini.<BR>
+${NetBots[Name].PetDuration[spellname]} :Ticks Duration of the buff on Name's pet if it has [spellname] buff. Requires Extended=1 in Name's ini.<BR>
+${NetBots[Name].TotalAA} :Int Total AAs Name has.<BR>
+${NetBots[Name].AAPointsTotal} :Int Total AAs Name has. (Same as TotalAA)<BR>
+${NetBots[Name].UsedAA} :Int Total spent AAs of Name.<BR>
+${NetBots[Name].AAPointsSpent} :Int Total spent AAs of Name. (Same as UsedAA)<BR>
+${NetBots[Name].UnusedAA} :Int Total unspent AAs of Name.<BR>
+${NetBots[Name].AAPoints} :Int Total unspent AAs of Name. (Same as UnusedAA)<BR>
+${NetBots[Name].AAPointsAssigned} :Int Total assigned AAs of Name.<BR>
+${NetBots[Name].CombatState} :Int Combat State of Name. 0=COMBAT,1=DEBUFFED,2=COOLDOWN,3=ACTIVE,4=RESTING.<BR>
+${NetBots[Name].Stacks[#]} :Bool Returns true if the spell ID number [#] will stack on Name. Implies no overwrites (will not stack if already present).<BR>
+${NetBots[Name].Stacks[spellname]} :Bool Returns true if the spell [spellname] will stack on Name. Implies no overwrites (will not stack if already present).<BR>
+${NetBots[Name].StacksPet[#]} :Bool Returns true if the spell ID number [#] will stack on Name's pet. Implies no overwrites (will not stack if already present).<BR>
+${NetBots[Name].StacksPet[spellname]} :Bool Returns true if the spell [spellname] will stack on Name's pet. Implies no overwrites (will not stack if already present).<BR>
+${NetBots[Name].WillLand[#]} :Bool Returns true if the spell ID number [#] will land on Name. Implies overwrites are OK (will land if already present).<BR>
+${NetBots[Name].WillLand[spellname]} :Bool Returns true if the spell [spellname] will land on Name. Implies overwrites are OK (will land if already present).<BR>
+${NetBots[Name].WillLandPet[#]} :Bool Returns true if the spell ID number [#] will land on Name's pet. Implies overwrites are OK (will land if already present).<BR>
+${NetBots[Name].WillLandPet[spellname]} :Bool Returns true if the spell [spellname] will land on Name's pet. Implies overwrites are OK (will land if already present).<BR>
+${NetBots[Name].TooPowerful[#]} :Bool Returns true if the spell ID number [#] is too powerful for Name. Can be used in conjunction with Stacks/Land. Optional since some EMU servers do not enforce this rule.<BR>
+${NetBots[Name].TooPowerful[spellname]} :Bool Returns true if the spell [spellname] is too powerful for Name. Can be used in conjunction with Stacks/Land. Optional since some EMU servers do not enforce this rule.<BR>
+${NetBots[Name].TooPowerfulPet[#]} :Bool Returns true if the spell ID number [#] is too powerful for Name's per. The results are not server-specific (some EMU servers do not enforce this rule).<BR>
+${NetBots[Name].TooPowerfulPet[spellname]} :Bool Returns true if the spell [spellname] is too powerful for Name's pet. The results are not server-specific (some EMU servers do not enforce this rule).<BR>
+${NetBots[Name].Query} :String The result of the Query in ini file as executed on Name.<BR>
+${NetBots[Name].Detrimentals} :Int64 Total number of detrimental spells on Name.<BR>
+${NetBots[Name].Counters} :Int64 Total number of detrimental spell counters (Curse/Disease/Poison/Corruption) on Name. (Same as TotalCounters)<BR>
+${NetBots[Name].TotalCounters} :Int64 Total number of detrimental spell counters (Curse/Disease/Poison/Corruption) on Name. (Same as Counters)<BR>
+${NetBots[Name].CountersCurse} :Int64 Total number of Curse counters on Name.<BR>
+${NetBots[Name].CountersDisease} :Int64 Total number of Disease counters on Name.<BR>
+${NetBots[Name].CountersPoison} :Int64 Total number of Poison counters on Name.<BR>
+${NetBots[Name].CountersCorruption} :Int64 Total number of Corruption counters on Name.<BR>
+${NetBots[Name].NoCure} :Int64 Total number of detrimentals marked as NoCure on Name.<BR>
+${NetBots[Name].EnduDrain} :Int64 Amount of Endurance drain per tick for Name.<BR>
+${NetBots[Name].LifeDrain} :Int64 Amount of HP drain per tick for Name.<BR>
+${NetBots[Name].ManaDrain} :Int64 Amount of Mana drain per tick for Name.<BR>
+${NetBots[Name].Cursed} :Int Is Name Cursed? (0/1)<BR>
+${NetBots[Name].Diseased} :Int Is Name Diseased? (0/1)<BR>
+${NetBots[Name].Poisoned} :Int Is Name Poisoned? (0/1)<BR>
+${NetBots[Name].Corrupted} :Int Is Name Corrupted? (0/1)<BR>
+${NetBots[Name].Blinded} :Int Is Name Blinded? (0/1)<BR>
+${NetBots[Name].CastingLevel} :Int Is the effective Casting Level of Name reduced? (0/1)<BR>
+${NetBots[Name].Charmed} :Int Is Name Charmed? (0/1)<BR>
+${NetBots[Name].Feared} :Int Is Name Feared? (0/1)<BR>
+${NetBots[Name].Healing} :Int Is Name Healing taken reduced? (0/1)<BR>
+${NetBots[Name].Invulnerable} :Int Is Name Invulnerable? (0/1)<BR>
+${NetBots[Name].Mesmerized} :Int Is Name Mesmerized? (0/1)<BR>
+${NetBots[Name].Rooted} :Int Is Name Rooted? (0/1)<BR>
+${NetBots[Name].Silenced} :Int Is Name Silenced? (0/1)<BR>
+${NetBots[Name].Slowed} :Int Is Name Slowed? (0/1)<BR>
+${NetBots[Name].Snared} :Int Is Name Snared? (0/1)<BR>
+${NetBots[Name].SpellCost} :Int Is Spell Mana Cost of Name increased? (0/1)<BR>
+${NetBots[Name].SpellSlowed} :Int Is the Spell Haste of Name reduced? (0/1)<BR>
+${NetBots[Name].SpellDamage} :Int Is the Spell Damage of Name reduced? (0/1)<BR>
+${NetBots[Name].Trigger} :Int Does Name have a cast on duration fade Trigger spell? (0/1)<BR>
+${NetBots[Name].Resistance} :Int Does Name have a Resistance reduction (Fire/Cold/Poison/Disease/Magic/Corruption)? (0/1)<BR>
+${NetBots[Name].RevDSed} :Int Does Name have a Reverse Damage shield on them? (0/1)<BR>
+${NetBots[Name].Crippled} :Int Is Name Crippled? (0/1)<BR>
+${NetBots[Name].Maloed} :Int Is Name Maloed? (0/1)<BR>
+${NetBots[Name].Tashed} :Int Is Name Tashed? (0/1)<BR>
+${NetBots[Name].Detrimental} :String A string list of all detrimental types affecting Name.<BR>
+${NetBots[Name].Hasted} :Int Is Name Hasted? (0/1)<BR>
+${NetBots[Name].DSed} :Int Does Name have a Damage Shield buff? (0/1)<BR>
+${NetBots[Name].Aego} :Int Does Name have an Cleric Aego line buff? (0/1)<BR>
+${NetBots[Name].Skin} :Int Does Name have a Druid Skin line buff? (0/1)<BR>
+${NetBots[Name].Focus} :Int Does Name have a Shaman Focus line buff? (0/1)<BR>
+${NetBots[Name].Regen} :Int Does Name have a non-Beastlord HP Regeneration buff? (0/1)<BR>
+${NetBots[Name].Symbol} :Int Does Name have a Cleric Symbol line buff? (0/1)<BR>
+${NetBots[Name].Clarity} :Int Does Name have an Enchanter Clarity line buff? (0/1)<BR>
+${NetBots[Name].Pred} :Int Does Name have a Ranger Predator line buff? (0/1)<BR>
+${NetBots[Name].Strength} :Int Does Name have a Ranger Strength line buff? (0/1)<BR>
+${NetBots[Name].Brells} :Int Does Name have a Paladin Brells line buff? (0/1)<BR>
+${NetBots[Name].SV} :Int Does Name have a Beastlord SV line buff? (0/1)<BR>
+${NetBots[Name].SE} :Int Does Name have a Beastlord SE line buff? (0/1)<BR>
+${NetBots[Name].HybridHP} :Int Does Name have a Ranger HP line buff? (0/1)<BR>
+${NetBots[Name].Growth} :Int Does Name have a Druid Growth type HP buff? (0/1)<BR>
+${NetBots[Name].Shining} :Int Does Name have a Cleric Shining line buff? (0/1)<BR>
+${NetBots[Name].Spell[spellline]} :Spell Returns the pSpellType of the specified spellline (from the above detrimentals/beneficials) on Name.<BR>
+${NetBots[Name].MacroState} :Int The macro state for Name. 0=No macro running, 1=Running, 2=Paused<BR>
+${NetBots[Name].MacroName} :String The running macro of Name, empty string if none running.<BR>
+${NetBots[Name].NavigationActive} :Bool Does Name have a running MQ2Nav path? (MQ2Nav)<BR>
+${NetBots[Name].NavigationPaused} :Bool Does Name have a paused MQ2Nav path? (MQ2Nav) <BR>
+${NetBots[Name].BotActive} :Bool Does Name have MQ2Bot active? (MQ2Bot)<BR>
+${NetBots[Name].MakeCampStatus} :Int The MakeCamp status (0=None/OFF,1=ON,2=PAUSED) of Name. (MQ2MoveUtils)<BR>
+${NetBots[Name].MakeCampX} :Float The X-Location of MakeCamp of Name. (MQ2MoveUtils)<BR>
+${NetBots[Name].MakeCampY} :Float The Y-location of MakeCamp of Name. (MQ2MoveUtils)<BR>
+${NetBots[Name].MakeCampRadius} :Float The Radius setting of MakeCamp of Name. (MQ2MoveUtils)<BR>
+${NetBots[Name].MakeCampDistance} :Float The Distance setting of MakeCamp of Name. (MQ2MoveUtils)<BR>
+${NetBots[Name].Lua} :String The LUA script names that Name is running. (Lua)<BR>
+${NetBots[Name].Packets} :Int64 The EQBC Packets of Name. Requires SendEQBCData=1 in ini. Not recommended. (MQ2EQBC)<BR>
+${NetBots[Name].HeartBeat} :Int64 The EQBC HeartBeat of Name. Requires SendEQBCData=1 in ini. Not recommended. (MQ2EQBC)<BR>

--- a/resources/uifiles/default/MQUI_NetBotsWnd.xml
+++ b/resources/uifiles/default/MQUI_NetBotsWnd.xml
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="us-ascii"?>
+<XML ID="EQInterfaceDefinitionLanguage">
+	<Schema xmlns="EverQuestData" xmlns:dt="EverQuestDataTypes" />
+
+<!-- New NB Window formats -->  
+	<Listbox item="NBW_Client_List">
+		<ScreenID>Client_List</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<AutoStretch>true</AutoStretch>
+		<RightAnchorToLeft>false</RightAnchorToLeft>
+		<BottomAnchorToTop>false</BottomAnchorToTop>
+		<Style_Border>false</Style_Border>
+		<Style_VScroll>false</Style_VScroll>
+		<Columns>
+			<Width>90</Width>
+			<Heading>Name</Heading>
+		</Columns>
+		<Columns>
+			<Width>25</Width>
+			<Heading></Heading>
+		</Columns>
+		<Columns>
+			<Width>2</Width>
+			<Heading></Heading>
+		</Columns>
+		<Columns>
+			<Width>35</Width>
+			<Heading></Heading>
+		</Columns>
+		<Columns>
+			<Width>30</Width>
+			<Heading> HP</Heading>
+		</Columns>
+		<Columns>
+			<Width>30</Width>
+			<Heading>  M</Heading>
+		</Columns>
+		<Columns>
+			<Width>30</Width>
+			<Heading>  E</Heading>
+		</Columns>
+		<Columns>
+			<Width>35</Width>
+			<Heading>Dist</Heading>
+		</Columns>
+		<Columns>
+			<Width>15</Width>
+			<Heading>S</Heading>
+		</Columns>
+		<Columns>
+			<Width>35</Width>
+			<Heading>Invis</Heading>
+		</Columns>
+		<Columns>
+			<Width>70</Width>
+			<Heading>Action</Heading>
+		</Columns>
+		<Columns>
+			<Width>200</Width>
+			<Heading>Target</Heading>
+		</Columns>
+	</Listbox>
+
+	<Screen item="NBClientWnd">
+		<RelativePosition>false</RelativePosition>
+		<Location>
+			<X>100</X>
+			<Y>100</Y>
+		</Location>
+		<Size>
+			<CX>600</CX>
+			<CY>100</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Text>MQ2NetBots Data</Text>
+		<DrawTemplate>WDT_Filigree</DrawTemplate>
+		<Style_Titlebar>true</Style_Titlebar>
+		<Style_Closebox>true</Style_Closebox>
+		<Style_Minimizebox>true</Style_Minimizebox>
+		<Style_Border>true</Style_Border>
+		<Style_Sizable>true</Style_Sizable>
+		<Pieces>NBW_Client_List</Pieces>
+	</Screen>
+
+
+<!-- Old NB Window formats -->  
+	<Listbox item = "NBW_List">
+		<ScreenID>NBW_List</ScreenID>
+		<DrawTemplate>WDT_Inner</DrawTemplate>
+		<Location>
+			<X>1</X>
+			<Y>1</Y>
+		</Location>
+		<Size>
+			<CX>600</CX>
+			<CY>1000</CY>
+		</Size>
+		<TextColor>
+			<R>255</R>
+			<G>255</G>
+			<B>255</B>
+		</TextColor>
+		<Style_Border>false</Style_Border>
+		<Style_VScroll>false</Style_VScroll>
+		<Columns>
+			<Width>30</Width>
+			<Heading> M</Heading>
+		</Columns>
+		<Columns>
+			<Width>30</Width>
+			<Heading>  E</Heading>
+		</Columns>
+		<Columns>
+			<Width>30</Width>
+			<Heading> HP</Heading>
+		</Columns>
+		<Columns>
+			<Width>50</Width>
+			<Heading> Dist</Heading>
+		</Columns>
+		<Columns>
+			<Width>20</Width>
+			<Heading></Heading>
+		</Columns>
+		<Columns>
+			<Width>90</Width>
+			<Heading>Name</Heading>
+		</Columns>
+		<Columns>
+			<Width>120</Width>
+			<Heading>Target</Heading>
+		</Columns>
+		<Columns>
+			<Width>150</Width>
+			<Heading>Action</Heading>
+		</Columns>
+	</Listbox>
+
+	<Screen item = "NetBotsWnd">
+		<RelativePosition>false</RelativePosition>
+		<Location>
+			<X>100</X>
+			<Y>100</Y>
+		</Location>
+		<Size>
+			<CX>600</CX>
+			<CY>100</CY>
+		</Size>
+		<Style_VScroll>false</Style_VScroll>
+		<Style_HScroll>false</Style_HScroll>
+		<Style_Transparent>false</Style_Transparent>
+		<Text>MQ2NetBots Data</Text>
+		<DrawTemplate>WDT_Rounded</DrawTemplate>
+		<Style_Titlebar>true</Style_Titlebar>
+		<Style_Closebox>true</Style_Closebox>
+		<Style_Minimizebox>true</Style_Minimizebox>
+		<Style_Border>true</Style_Border>
+		<Style_Sizable>true</Style_Sizable>
+		<Pieces>NBW_List</Pieces>
+	</Screen>
+</XML>


### PR DESCRIPTION
- Merged in MMOBUGS data items and in-game window (thank you MMOBUGS).
- Added Detrimental/Beneficial buff type data items.
- Remove internal Stacks/StacksPet. Use new EQ/MQ coding.
- Added WillLand, WillLandPet, TooPowerful, TooPowerfulPet.
- Added Extended data options for Gems and Buff/Song/Pet Durations.
- Added TotalCounters, CountersCurse, CountersDisease, CountersPoison, CountersCorruption to accurately report current counters on the client (not counters on the spell).
- Added PetAffinity and AAPointsAssigned.
- Added a new version of the in-game window (switchable with old) along with new ini and command options. LClick, RClick, ConColors, CleanNames. 
- Code clean-up. 